### PR TITLE
Monkey patch slack-client sendMessage method

### DIFF
--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -61,7 +61,23 @@ function isNotNull(value) {
   return (!value) || value === 'null';
 }
 
+function sendMessageRaw(message) {
+  message['channel'] = this.id;
+  message['parse'] = 'none'
+  this._client._send(message);
+}
+
 module.exports = function(robot) {
+  // We monkey patch sendMessage function to send "parse" argument with the message so the text is not
+  // formatted and parsed on the server side.
+  // NOTE / TODO: We can get rid of this nasty patch once our node-slack-client and hubot-slack pull
+  // requests are merged.
+  if (robot.adapter && robot.adapter.constructor && robot.adapter.constructor.name == 'SlackBot') {
+    for (var channel in robot.adapter.client.channels) {
+      robot.adapter.client.channels[channel].sendMessage = sendMessageRaw.bind(robot.adapter.client.channels[channel]);
+    }
+  }
+
   var self = this;
 
   // Stores a list of hubot command strings

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -62,8 +62,9 @@ function isNotNull(value) {
 }
 
 function sendMessageRaw(message) {
+  /*jshint validthis:true */
   message['channel'] = this.id;
-  message['parse'] = 'none'
+  message['parse'] = 'none';
   this._client._send(message);
 }
 
@@ -72,7 +73,7 @@ module.exports = function(robot) {
   // formatted and parsed on the server side.
   // NOTE / TODO: We can get rid of this nasty patch once our node-slack-client and hubot-slack pull
   // requests are merged.
-  if (robot.adapter && robot.adapter.constructor && robot.adapter.constructor.name == 'SlackBot') {
+  if (robot.adapter && robot.adapter.constructor && robot.adapter.constructor.name === 'SlackBot') {
     for (var channel in robot.adapter.client.channels) {
       robot.adapter.client.channels[channel].sendMessage = sendMessageRaw.bind(robot.adapter.client.channels[channel]);
     }


### PR DESCRIPTION
This is a temporary work-around until our pull request gets merged.

The difference between our and upstream `sendMessage` method is that we also send `parse` attribute letting slack API know to not parse and format the message.