### PR TITLE
[RFR] Modify format regex to allow for defaults

### DIFF
--- a/lib/st2_command_factory.js
+++ b/lib/st2_command_factory.js
@@ -1,0 +1,120 @@
+/*
+ Licensed to the StackStorm, Inc ('StackStorm') under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+"use strict";
+
+var _ = require('lodash');
+
+/**
+ * Manage command for stackstorm, storing them in robot and providing
+ * lookups given command literals.
+ */
+function CommandFactory(robot) {
+  this.robot = robot;
+
+  // Stores a list of hubot command strings
+  this.st2_hubot_commands = [];
+
+  // Maps command name (pk) to the action alias object
+  this.st2_commands_name_map = {};
+
+  // Maps command format to the action alias object
+  this.st2_commands_format_map = {};
+
+  // Maps command format to a compiled regex for that format
+  this.st2_commands_regex_map = {};
+}
+
+CommandFactory.prototype.getRegexForFormatString = function(format) {
+  var regex_str, regex;
+
+  // Note: We replace format parameters with (.+?) and allow arbitrary
+  // number of key=value pairs at the end of the string
+  // Format parameters with default value {{param=value}} are allowed to
+  // be skipped.
+  regex_str = format.replace(/\s+{{\w+\s*=.+?}}/g, '(\\s+)?(.*?)');
+  regex_str = regex_str.replace(/{{.+?}}/g, '(.+?)');
+  regex = new RegExp(regex_str + '(\\s+)?(\\s?(\\w+)=(\\w+)){0,}' + '$');
+
+  return regex;
+};
+
+CommandFactory.prototype.addCommand = function(command, name, format, action_alias) {
+  var compiled_template, context, command_string, regex;
+
+  if (!format) {
+    this.robot.logger.error('Skipped empty command.');
+    return;
+  }
+
+  context = {
+    robotName: this.robot.name,
+    command: command
+  };
+
+  compiled_template = _.template('${robotName} ${command}');
+  command_string = compiled_template(context);
+
+  this.robot.commands.push(command_string);
+
+  regex = this.getRegexForFormatString(format);
+  this.st2_hubot_commands.push(command_string);
+  this.st2_commands_name_map[name] = action_alias;
+  this.st2_commands_format_map[format] = action_alias;
+  this.st2_commands_regex_map[format] = regex;
+
+  this.robot.logger.debug('Added command: ' + command);
+};
+
+CommandFactory.prototype.removeCommands = function() {
+  var i, command, array_index;
+
+  for (i = 0; i < this.st2_hubot_commands.length; i++) {
+    command = this.st2_hubot_commands[i];
+    array_index = this.robot.commands.indexOf(command);
+
+    if (array_index !== -1) {
+      this.robot.commands.splice(array_index, 1);
+    }
+  }
+
+  this.st2_hubot_commands = [];
+  this.st2_commands_name_map = {};
+  this.st2_commands_format_map = {};
+  this.st2_commands_regex_map = {};
+};
+
+CommandFactory.prototype.getMatchingCommand = function(command) {
+  var result, common_prefix, command_name, command_arguments, format_strings, i, format_string, regex;
+
+  // 1. Try to use regex search - this works for commands with a format string
+  format_strings = Object.keys(this.st2_commands_regex_map);
+
+  for (i = 0; i < format_strings.length; i++) {
+    format_string = format_strings[i];
+    regex = this.st2_commands_regex_map[format_string];
+
+    if (regex.test(command)) {
+      command_name = this.st2_commands_format_map[format_string].name;
+      return [command_name, format_string];
+    }
+  }
+
+  return null;
+};
+
+module.exports = CommandFactory;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "hubot-help": "^0.1.1",
     "hubot-mock-adapter": "~1.0.0",
     "jshint": "^2.7.0",
-    "jshint-stylish": "^2.0.0"
+    "jshint-stylish": "^2.0.0",
+    "log": "1.4.0"
   },
   "main": "index.js",
   "scripts": {

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -218,7 +218,10 @@ module.exports = function(robot) {
 
     // Note: We replace format parameters with (.+?) and allow arbitrary
     // number of key=value pairs at the end of the string
-    regex_str = format.replace(/{{.+?}}/g, '(.+?)');
+    // Format parameters with default value {{param=value}} are allowed to
+    // be skipped.
+    regex_str = format.replace(/\s+{{\w+\s*=.+?}}/g, '(\\s+)?(.*?)');
+    regex_str = regex_str.replace(/{{.+?}}/g, '(.+?)');
     regex = new RegExp(regex_str + '(\\s+)?(\\s?(\\w+)=(\\w+)){0,}' + '$');
 
     return regex;

--- a/tests/dummy-robot.js
+++ b/tests/dummy-robot.js
@@ -1,0 +1,62 @@
+/*
+ Licensed to the StackStorm, Inc ('StackStorm') under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+"use strict";
+
+var Log = require('log');
+
+function Logger(enabled) {
+  this.enabled = enabled;
+  this.log = new Log('debug');
+
+  this.error = function(msg) {
+    if (!this.enabled) {
+      return;
+    }
+    this.log.error(msg);
+  };
+
+  this.warn = function(msg) {
+    if (!this.enabled) {
+      return;
+    }
+    this.log.warn(msg);
+  };
+
+  this.info = function(msg) {
+    if (!this.enabled) {
+      return;
+    }
+    this.log.info(msg);
+  };
+
+  this.debug = function(msg) {
+    if (!this.enabled) {
+      return;
+    }
+    this.log.debug(msg);
+  };
+
+}
+
+function Robot(name, enable_logging) {
+  this.logger = new Logger(enable_logging);
+  this.name = name;
+  this.commands = [];
+}
+
+module.exports = Robot;

--- a/tests/fixtures/aliases.json
+++ b/tests/fixtures/aliases.json
@@ -1,0 +1,20 @@
+[{
+  "name": "alias1",
+  "description": "alias1",
+  "formats": [
+    "alias1 fmt1 {{param}} breaking words {{param2=default}}"
+  ]
+}, {
+  "name": "alias2",
+  "description": "alias2",
+  "formats": [
+    "alias2 fmt1 {{param1}} {{param2}}",
+    "alias2 fmt2 {{param1}} some more words"
+  ]
+}, {
+  "name": "alias3",
+  "description": "alias3",
+  "formats": [
+    "alias3 fmt1 {{param1}} {{param2}} {{param3=default}} trailing words"
+  ]
+}]

--- a/tests/test-st2-command-factory.js
+++ b/tests/test-st2-command-factory.js
@@ -1,0 +1,130 @@
+/*
+ Licensed to the StackStorm, Inc ('StackStorm') under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*jshint quotmark:false*/
+/*global describe, it*/
+"use strict";
+
+var fs = require('fs'),
+  chai = require('chai'),
+  assert = chai.assert,
+  expect = chai.expect,
+  CommandFactory = require('../lib/st2_command_factory.js'),
+  Robot = require('./dummy-robot.js'),
+  formatCommand = require('../lib/format_command.js');
+
+var alias_fixtures;
+
+fs.readFile('tests/fixtures/aliases.json', function(err, data) {
+  if (err) {
+    throw err;
+  }
+  alias_fixtures = JSON.parse(data);
+});
+
+function getCleanCommandFactory() {
+  var robot = new Robot(false);
+  return new CommandFactory(robot);
+}
+
+describe('command factory', function() {
+  it('should add commands to robot', function() {
+    var command_factory, alias;
+
+    command_factory = getCleanCommandFactory();
+    alias = alias_fixtures[0];
+
+    command_factory.addCommand(
+      formatCommand(null, alias.name, alias.formats[0], alias.description),
+      alias.name,
+      alias.formats[0],
+      alias);
+
+    expect(command_factory.robot.commands).to.have.length(1);
+  });
+
+  it('should add multiple commands to robot', function() {
+    var command_factory, alias, alias_format, idx_a, idx_f, alias_count;
+
+    alias_count = 0;
+    command_factory = getCleanCommandFactory();
+
+    for (idx_a = 0; idx_a < alias_fixtures.length; idx_a++) {
+      alias = alias_fixtures[idx_a];
+      for (idx_f = 0; idx_f < alias.formats.length; idx_f++) {
+        alias_format = alias.formats[idx_f];
+        command_factory.addCommand(
+          formatCommand(null, alias.name, alias_format, alias.description),
+          alias.name,
+          alias_format,
+          alias);
+        alias_count++;
+      }
+    }
+
+    expect(command_factory.robot.commands).to.have.length(alias_count);
+  });
+
+  it('should match various command literals for same format with defaults', function() {
+    var command_factory, alias, match;
+
+    command_factory = getCleanCommandFactory();
+    alias = alias_fixtures[0];
+
+    command_factory.addCommand(
+      formatCommand(null, alias.name, alias.formats[0], alias.description),
+      alias.name,
+      alias.formats[0],
+      alias);
+
+    expect(command_factory.robot.commands).to.have.length(1);
+
+    match = command_factory.getMatchingCommand('alias1 fmt1 value1 breaking words value2');
+    expect(match[0]).to.equal('alias1');
+
+    match = command_factory.getMatchingCommand('alias1 fmt1 value1 breaking words');
+    expect(match[0]).to.equal('alias1');
+
+  });
+
+  it('should match command literals for various formats of an alias', function() {
+    var command_factory, alias, alias_format, match, idx_f;
+
+    command_factory = getCleanCommandFactory();
+    alias = alias_fixtures[1];
+
+    for (idx_f = 0; idx_f < alias.formats.length; idx_f++) {
+      alias_format = alias.formats[idx_f];
+      command_factory.addCommand(
+        formatCommand(null, alias.name, alias_format, alias.description),
+        alias.name,
+        alias_format,
+        alias);
+    }
+
+    expect(command_factory.robot.commands).to.have.length(2);
+
+    match = command_factory.getMatchingCommand('alias2 fmt1 value1 value2');
+    expect(match[0]).to.equal('alias2');
+    expect(match[1]).to.equal('alias2 fmt1 {{param1}} {{param2}}');
+
+    match = command_factory.getMatchingCommand('alias2 fmt2 value1 some more words');
+    expect(match[0]).to.equal('alias2');
+    expect(match[1]).to.equal('alias2 fmt2 {{param1}} some more words');
+  });
+
+});


### PR DESCRIPTION
* A format like google {{query}} {{count=10}} will not work for the following command literals
  1. google stackstorm
  2. google stackstorm 7
  3. google stackstorm count=5