### PR TITLE
Fix a default port propagation bug

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,6 +15,7 @@
  limitations under the License.
  */
 
+var url = require('url');
 var util = require('util');
 var env = process.env;
 
@@ -60,7 +61,34 @@ function getExecutionIdFromMessage(message) {
   return execution_id;
 }
 
+function parseUrl(url_string) {
+  var parsed, result;
+
+  parsed = url.parse(url_string);
+
+  result = {};
+  result['hostname'] = parsed['hostname'];
+  result['protocol'] = parsed['protocol'].substring(0, (parsed['protocol'].length - 1));
+
+  if (parsed['port'] !== null) {
+    result['port'] = parsed['port'];
+  }
+  else {
+    if (result['protocol'] === 'http') {
+      result['port'] = 80;
+    }
+    else {
+      result['port'] = 443;
+    }
+  }
+
+  result['path'] = parsed['path'];
+
+  return result;
+}
+
 
 exports.isNull = isNull;
 exports.getExecutionHistoryUrl = getExecutionHistoryUrl;
 exports.getExecutionIdFromMessage = getExecutionIdFromMessage;
+exports.parseUrl = parseUrl;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -71,7 +71,7 @@ function parseUrl(url_string) {
   result['protocol'] = parsed['protocol'].substring(0, (parsed['protocol'].length - 1));
 
   if (parsed['port'] !== null) {
-    result['port'] = parsed['port'];
+    result['port'] = parseInt(parsed['port'], 10);
   }
   else {
     if (result['protocol'] === 'http') {

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -32,8 +32,6 @@ limitations under the License.
 
 "use strict";
 
-var url = require('url');
-
 var _ = require('lodash'),
   util = require('util'),
   env = process.env,
@@ -263,18 +261,19 @@ module.exports = function(robot) {
     };
 
     if (!utils.isNull(env.ST2_AUTH_URL)) {
-      parsed = url.parse(env.ST2_AUTH_URL);
+      parsed = utils.parseUrl(env.ST2_AUTH_URL);
 
       config['auth'] = {};
       config['auth']['host'] = parsed['hostname'];
+      config['auth']['protocol'] = parsed['protocol'];
       config['auth']['port'] = parsed['port'];
-      config['auth']['protocol'] = parsed['protocol'].substring(0, (parsed['protocol'].length - 1));
-    } else {
-      parsed = url.parse(env.ST2_API);
+    }
+    else {
+      parsed = utils.parseUrl(env.ST2_API);
 
       config['host'] = parsed['hostname'];
+      config['protocol'] = parsed['protocol'];
       config['port'] = parsed['port'];
-      config['protocol'] = parsed['protocol'].substring(0, (parsed['protocol'].length - 1));
     }
 
     st2_client = st2client(config);

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -170,7 +170,7 @@ module.exports = function(robot) {
           execution_id = _.trim(body, '"');
           history_url = utils.getExecutionHistoryUrl(execution_id);
 
-          message = START_MESSAGES[_.random(0, START_MESSAGES.length)];
+          message = START_MESSAGES[_.random(0, START_MESSAGES.length - 1)];
           message = util.format(message, execution_id);
 
           if (history_url) {

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -59,7 +59,6 @@ describe('getExecutionHistoryUrl', function() {
   });
 });
 
-
 describe('getExecutionIdFromMessage', function() {
   it('should return null on empty message', function() {
     var result = utils.getExecutionIdFromMessage(null);
@@ -75,5 +74,35 @@ describe('getExecutionIdFromMessage', function() {
     var result = utils.getExecutionIdFromMessage(MOCK_MESSAGE);
     console.log(result);
     expect(result).to.be.equal('55701c8b0640fd53cdf4f08');
+  });
+});
+
+describe('parseUrl', function() {
+  it('should correctly parse values', function() {
+    var result = utils.parseUrl('http://www.example.com/a')
+    expect(result['hostname']).to.be.equal('www.example.com');
+    expect(result['protocol']).to.be.equal('http');
+    expect(result['port']).to.be.equal(80);
+    expect(result['path']).to.be.equal('/a');
+  });
+
+  it('should correctly parrse ports', function() {
+    var result = utils.parseUrl('http://www.example.com:8080')
+      expect(result['port']).to.be.equal(8080);
+
+    var result = utils.parseUrl('https://www.example.com:8181')
+      expect(result['port']).to.be.equal(8181);
+  });
+
+  it('should use default http port on port not specified', function() {
+    var result = utils.parseUrl('http://www.example.com/a')
+    expect(result['protocol']).to.be.equal('http');
+    expect(result['port']).to.be.equal(80);
+  });
+
+  it('should use default https port on port not specified', function() {
+    var result = utils.parseUrl('https://www.example.com/a')
+    expect(result['protocol']).to.be.equal('https');
+    expect(result['port']).to.be.equal(443);
   });
 });


### PR DESCRIPTION
Previously, if the api or auth URL didn't contain a port, a default port (80 for https and 443) was not correctly propagated which meant the requests wouldn't work (they would time out).