### PR TITLE
Reload available commands on SIGUSR2 signal

### DIFF
--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -287,7 +287,13 @@ module.exports = function(robot) {
       robot.logger.error('Failed to authenticate: ' + err.message.toString());
       process.exit(2);
     });
-  } else {
-    return start();
   }
+  else {
+    start();
+  }
+
+  // Install SIGUSR2 handler which reloads the command
+  process.on('SIGUSR2', function() {
+    loadCommands();
+  });
 };

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -244,7 +244,17 @@ module.exports = function(robot) {
 
     // Initial command loading
     loadCommands();
+
+    // Install SIGUSR2 handler which reloads the command
+    install_sigusr2_handler();
+
     return commands_load_interval;
+  }
+
+  function install_sigusr2_handler() {
+    process.on('SIGUSR2', function() {
+      loadCommands();
+    });
   }
 
   // TODO: Use async.js or similar or organize this better
@@ -289,11 +299,6 @@ module.exports = function(robot) {
     });
   }
   else {
-    start();
+    return start();
   }
-
-  // Install SIGUSR2 handler which reloads the command
-  process.on('SIGUSR2', function() {
-    loadCommands();
-  });
 };

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -290,5 +290,4 @@ module.exports = function(robot) {
       reject(err);
     });
   });
-
 };

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -79,7 +79,7 @@ describe('getExecutionIdFromMessage', function() {
 
 describe('parseUrl', function() {
   it('should correctly parse values', function() {
-    var result = utils.parseUrl('http://www.example.com/a')
+    var result = utils.parseUrl('http://www.example.com/a');
     expect(result['hostname']).to.be.equal('www.example.com');
     expect(result['protocol']).to.be.equal('http');
     expect(result['port']).to.be.equal(80);
@@ -87,21 +87,23 @@ describe('parseUrl', function() {
   });
 
   it('should correctly parrse ports', function() {
-    var result = utils.parseUrl('http://www.example.com:8080')
+    var result;
+
+    result = utils.parseUrl('http://www.example.com:8080');
       expect(result['port']).to.be.equal(8080);
 
-    var result = utils.parseUrl('https://www.example.com:8181')
+    result = utils.parseUrl('https://www.example.com:8181');
       expect(result['port']).to.be.equal(8181);
   });
 
   it('should use default http port on port not specified', function() {
-    var result = utils.parseUrl('http://www.example.com/a')
+    var result = utils.parseUrl('http://www.example.com/a');
     expect(result['protocol']).to.be.equal('http');
     expect(result['port']).to.be.equal(80);
   });
 
   it('should use default https port on port not specified', function() {
-    var result = utils.parseUrl('https://www.example.com/a')
+    var result = utils.parseUrl('https://www.example.com/a');
     expect(result['protocol']).to.be.equal('https');
     expect(result['port']).to.be.equal(443);
   });


### PR DESCRIPTION
If user doesn't want to wait on the periodic commands reload they can now also send `SIGUSR2` signal to the bot process which will cause it to reload the commands without a restart.