### PR TITLE
Don't hardcode node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "lint": "gulp lint"
   },
   "engines": {
-    "node": "0.10.x"
+    "node": ">= 0.10.x"
   }
 }


### PR DESCRIPTION
Getting warn:
```sh
npm WARN engine hubot-stackstorm@0.1.1: wanted: {"node":"0.10.x"} (current: {"node":"0.12.4","npm":"2.10.1"})
```

Is the only required node version `0.10.x` or we can extend it to `>= 0.10.x`?

See: 
https://github.com/github/hubot/blob/master/package.json#L34
https://github.com/github/generator-hubot/blob/master/package.json#L14
https://github.com/yeoman/yo/blob/master/package.json#L10