### PR TITLE
Support Hipchat channel type and message format

### DIFF
--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -209,7 +209,7 @@ module.exports = function(robot) {
       } else {
         data = req.body;
       }
-      if (robot.adapterName == "hipchat") {
+      if (robot.adapterName === "hipchat") {
         message = data.message;
       }
       else {
@@ -235,7 +235,7 @@ module.exports = function(robot) {
         message += util.format('\n Execution details available at: %s', history_url);
       }
 
-      if (robot.adapterName == "hipchat" ) {
+      if (robot.adapterName === "hipchat" ) {
         robot.logger.info('Using adapter ' + robot.adapterName + '. Modifying the recipient.');
         var robot_name = env.HUBOT_HIPCHAT_JID.split("_", 1);
         recipient = robot_name + "_" + recipient + "@conf.hipchat.com";

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -209,7 +209,12 @@ module.exports = function(robot) {
       } else {
         data = req.body;
       }
-      message = formatData(data.message, '', robot.logger);
+      if (robot.adapterName == "hipchat") {
+        message = data.message;
+      }
+      else {
+        message = formatData(data.message, '', robot.logger);
+      }
 
       // PM user, notify user, or tell channel
       if (data.user) {
@@ -228,6 +233,12 @@ module.exports = function(robot) {
 
       if (history_url) {
         message += util.format('\n Execution details available at: %s', history_url);
+      }
+
+      if (robot.adapterName == "hipchat" ) {
+        robot.logger.info('Using adapter ' + robot.adapterName + '. Modifying the recipient.');
+        var robot_name = env.HUBOT_HIPCHAT_JID.split("_", 1);
+        recipient = robot_name + "_" + recipient + "@conf.hipchat.com";
       }
 
       robot.messageRoom(recipient, message);


### PR DESCRIPTION
Taking advantage of ```robot.adapterName``` to provide compatibility with Hipchat. Modifies the message to not add the ```basic``` format (which I guess gets properly displayed in Slack) and also modifies the channel to send to, so the results appear properly (on hipchat the channel real name is BOTJID_CHANNELNAME@conf.hipchat.com)

Tested and can see the result of actions asked in the proper channel.

@Kami ?