### PR TITLE
Break out auth in its owns module

### DIFF
--- a/lib/st2_authenticate.js
+++ b/lib/st2_authenticate.js
@@ -83,13 +83,13 @@ var authenticate = function(st2AuthUrl, st2ApiUrl, username, password, logger) {
         resolve(result);
       }).catch(function(err) {
         if (retry_count < env.ST2_AUTH_RETRY_COUNT) {
-            logger.debug(util.format('Failed to authenticate. retry_count : %s.', retry_count+1));
-            // schedule auth retry after a set amount of time.
-            setTimeout(do_retry_auth(retry_count + 1).bind(self), env.ST2_AUTH_RETRY_INTERVAL * 1000);
+          logger.debug(util.format('Failed to authenticate. retry_count : %s.', retry_count+1));
+          // schedule auth retry after a set amount of time.
+          setTimeout(do_retry_auth.bind(self), env.ST2_AUTH_RETRY_INTERVAL * 1000, retry_count + 1);
         } else {
           reject({
             name: 'St2AuthenticationError',
-            message: 'Authentication failed : [' + err.name + ': ' + err.message + ']'
+            message: 'Authentication failed : [' + err.name + ': ' + err.message + ' after ' + retry_count + ' retries.]'
           });
         }
       });

--- a/lib/st2_authenticate.js
+++ b/lib/st2_authenticate.js
@@ -20,6 +20,7 @@ limitations under the License.
 var _ = require('lodash'),
   env = process.env,
   Promise = require('rsvp').Promise,
+  st2client = require('st2client'),
   util = require('util'),
   utils = require('../lib/utils.js');
 
@@ -29,7 +30,7 @@ env.ST2_AUTH_RETRY_INTERVAL = parseInt(env.ST2_AUTH_RETRY_INTERVAL || 5);
 
 var authenticate = function(st2AuthUrl, st2ApiUrl, username, password, logger) {
   return new Promise(function (resolve, reject) {
-    result = {};
+    var result = {};
     if (utils.isNull(username) && utils.isNull(password)) {
       // No username & no password therefore assume no auth.
       result['token'] = null;
@@ -44,6 +45,7 @@ var authenticate = function(st2AuthUrl, st2ApiUrl, username, password, logger) {
 
     // Now really try to authenticate.
     var credentials, config, st2_client, parsed;
+    var self = this;
 
     credentials = {
       'user': username,
@@ -83,7 +85,7 @@ var authenticate = function(st2AuthUrl, st2ApiUrl, username, password, logger) {
         if (retry_count < env.ST2_AUTH_RETRY_COUNT) {
             logger.debug(util.format('Failed to authenticate. retry_count : %s.', retry_count+1));
             // schedule auth retry after a set amount of time.
-            setDelay(do_retry_auth(retry_count + 1).bind(self), env.ST2_AUTH_RETRY_INTERVAL * 1000);
+            setTimeout(do_retry_auth(retry_count + 1).bind(self), env.ST2_AUTH_RETRY_INTERVAL * 1000);
         } else {
           reject({
             name: 'St2AuthenticationError',

--- a/lib/st2_authenticate.js
+++ b/lib/st2_authenticate.js
@@ -1,0 +1,101 @@
+/*
+ Licensed to the StackStorm, Inc ('StackStorm') under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+"use strict";
+
+var _ = require('lodash'),
+  env = process.env,
+  Promise = require('rsvp').Promise,
+  util = require('util'),
+  utils = require('../lib/utils.js');
+
+// Controls around how many retries and interval between retry etc.
+env.ST2_AUTH_RETRY_COUNT = parseInt(env.ST2_AUTH_RETRY || 10);
+env.ST2_AUTH_RETRY_INTERVAL = parseInt(env.ST2_AUTH_RETRY_INTERVAL || 5);
+
+var authenticate = function(st2AuthUrl, st2ApiUrl, username, password, logger) {
+  return new Promise(function (resolve, reject) {
+    result = {};
+    if (utils.isNull(username) && utils.isNull(password)) {
+      // No username & no password therefore assume no auth.
+      result['token'] = null;
+      resolve(result);
+    }
+    if (utils.isNull(username) || utils.isNull(password)) {
+      reject({
+        name: 'St2AuthenticationError',
+        message: 'Both username and password must be provided to authenticate.'
+      });
+    }
+
+    // Now really try to authenticate.
+    var credentials, config, st2_client, parsed;
+
+    credentials = {
+      'user': username,
+      'password': password
+    };
+    config = {
+      'rejectUnauthorized': false,
+      'credentials': credentials
+    };
+
+    if (!utils.isNull(st2AuthUrl)) {
+      parsed = utils.parseUrl(st2AuthUrl);
+
+      config['auth'] = {};
+      config['auth']['host'] = parsed['hostname'];
+      config['auth']['protocol'] = parsed['protocol'];
+      config['auth']['port'] = parsed['port'];
+    }
+    else {
+      parsed = utils.parseUrl(st2ApiUrl);
+
+      config['host'] = parsed['hostname'];
+      config['protocol'] = parsed['protocol'];
+      config['port'] = parsed['port'];
+    }
+
+    st2_client = st2client(config);
+    logger.info('Performing authentication...');
+
+    // Wrap up in a function to support retry of authentication
+    var do_retry_auth = function(retry_count) {
+      st2_client.authenticate(config.credentials.user, config.credentials.password)
+      .then(function(result) {
+        logger.debug('Successfully authenticated.');
+        resolve(result);
+      }).catch(function(err) {
+        if (retry_count < env.ST2_AUTH_RETRY_COUNT) {
+            logger.debug(util.format('Failed to authenticate. retry_count : %s.', retry_count+1));
+            // schedule auth retry after a set amount of time.
+            setDelay(do_retry_auth(retry_count + 1).bind(self), env.ST2_AUTH_RETRY_INTERVAL * 1000);
+        } else {
+          reject({
+            name: 'St2AuthenticationError',
+            message: 'Authentication failed : [' + err.name + ': ' + err.message + ']'
+          });
+        }
+      });
+    };
+
+    do_retry_auth(0);
+
+  });
+};
+
+module.exports = authenticate;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "lodash": "~3.8.0",
     "cli-table": "<=1.0.0",
+    "rsvp": "3.0.14",
     "st2client": "~0.3.3"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "hubot-mock-adapter": "~1.0.0",
     "jshint": "^2.7.0",
     "jshint-stylish": "^2.0.0",
-    "log": "1.4.0"
+    "log": "1.4.0",
+    "nock": "^0.50.0"
   },
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "hubot": "2.x"
   },
   "devDependencies": {
-    "chai": "^1.9.1",
+    "chai": "^3.0.0",
+    "chai-as-promised": "^5.1.0",
     "coffee-script": "~1.7.1",
     "gulp": "~3.8.11",
     "gulp-jshint": "^1.9.0",

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -39,10 +39,8 @@ var _ = require('lodash'),
   slack_monkey_patch = require('../lib/slack_monkey_patch.js'),
   formatCommand = require('../lib/format_command.js'),
   formatData = require('../lib/format_data.js'),
-  CommandFactory = require('../lib/command_factory.js');
-  authenticate = require('../lib/st2_authenticate.js')
-
-var st2client = require('st2client');
+  CommandFactory = require('../lib/command_factory.js'),
+  authenticate = require('../lib/st2_authenticate.js');
 
 // Setup the Environment
 env.ST2_API = env.ST2_API || 'http://localhost:9101';
@@ -247,10 +245,11 @@ module.exports = function(robot) {
     return commands_load_interval;
   }
 
+
   // Authenticate with StackStorm backend and then call start.
   // On a failure to
   authenticate(env.ST2_AUTH_URL, env.ST2_API, env.ST2_AUTH_USERNAME, env.ST2_AUTH_PASSWORD)
-  .then(function() {
+  .then(function(result) {
     auth_token = result['token'];
     return start();
   })

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -249,7 +249,7 @@ module.exports = function(robot) {
   // Authenticate with StackStorm backend and then call start.
   // On a failure to authenticate log the error but do not quit.
   return new Promise(function(resolve, reject) {
-    authenticate(env.ST2_AUTH_URL, env.ST2_API, env.ST2_AUTH_USERNAME, env.ST2_AUTH_PASSWORD)
+    authenticate(env.ST2_AUTH_URL, env.ST2_API, env.ST2_AUTH_USERNAME, env.ST2_AUTH_PASSWORD, robot.logger)
     .then(function(result) {
       auth_token = result['token'];
       result = start();

--- a/tests/test-st2-authenticate.js
+++ b/tests/test-st2-authenticate.js
@@ -43,7 +43,7 @@ describe('st2 authentication', function() {
   it('should treat no username and password as auth disabled.', function() {
     var expected_response = {
       token: null
-    }
+    };
     return expect(authenticate('', '', null, null, getLogger())).to.eventually.be.deep.equal(expected_response);
   });
 
@@ -78,7 +78,7 @@ describe('st2 authentication', function() {
     nock('http://test:9100/').post('/tokens').reply(400, response);
     // adjust the env variable.
     env.ST2_AUTH_RETRY_INTERVAL = 0.001;
-    var result = authenticate('http://test:9100/tokens', '', username, password, getLogger())
+    var result = authenticate('http://test:9100/tokens', '', username, password, getLogger());
     return expect(result).to.be.rejected;
   });
 

--- a/tests/test-st2-authenticate.js
+++ b/tests/test-st2-authenticate.js
@@ -1,0 +1,103 @@
+/*
+ Licensed to the StackStorm, Inc ('StackStorm') under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/*jshint quotmark:false*/
+/*global describe, it*/
+"use strict";
+
+var chai = require('chai'),
+  chaiAsPromied = require('chai-as-promised'),
+  env = process.env,
+  nock = require('nock'),
+  Robot = require('./dummy-robot.js'),
+  rsvp = require('rsvp'),
+  authenticate = require('../lib/st2_authenticate.js');
+
+chai.use(chaiAsPromied);
+nock.disableNetConnect();
+
+var all = rsvp.all,
+  assert = chai.assert,
+  expect = chai.expect;
+
+function getLogger() {
+  var robot = new Robot(false);
+  return robot.logger;
+}
+
+describe('st2 authentication', function() {
+  it('should treat no username and password as auth disabled.', function() {
+    var expected_response = {
+      token: null
+    }
+    return expect(authenticate('', '', null, null, getLogger())).to.eventually.be.deep.equal(expected_response);
+  });
+
+  it('should require password if username is provided.', function() {
+    return expect(authenticate('', '', 'stanley', null, null)).to.be.rejectedWith(
+      'Both username and password must be provided to authenticate.');
+  });
+
+  it('should require username if password is provided.', function() {
+    return expect(authenticate('', '', null, 'junk', null)).to.be.rejectedWith(
+      'Both username and password must be provided to authenticate.');
+  });
+
+  it('should authenticate.', function() {
+    var username = 'stanley',
+      password = 'rocks',
+      response = {token: 'some_token'};
+    nock('http://test:9100/').post('/tokens').reply(201, response);
+
+    var result = authenticate('http://test:9100/tokens', '', username, password, getLogger());
+
+    return all([
+      expect(result).to.eventually.be.an('object'),
+      expect(result).to.eventually.be.deep.equal(response)
+    ]);
+  });
+
+  it('should fail to authenticate.', function() {
+    var username = 'stanley',
+      password = 'rocks',
+      response = {};
+    nock('http://test:9100/').post('/tokens').reply(400, response);
+    // adjust the env variable.
+    env.ST2_AUTH_RETRY_INTERVAL = 0.001;
+    var result = authenticate('http://test:9100/tokens', '', username, password, getLogger())
+    return expect(result).to.be.rejected;
+  });
+
+  it('should eventually authenticate.', function() {
+    var username = 'stanley',
+      password = 'rocks',
+      response = {token: 'some_token'};
+    // Will fail 5 time and respond with a token the 6th. Btw, the ability of nock to do
+    // this is absolutely incredible.
+    nock('http://test:9100/').post('/tokens').times(5).reply(400, response);
+    nock('http://test:9100/').post('/tokens').reply(201, response);
+    env.ST2_AUTH_RETRY_INTERVAL = 0.001;
+
+    var result = authenticate('http://test:9100/tokens', '', username, password, getLogger());
+
+    return all([
+      expect(result).to.eventually.be.an('object'),
+      expect(result).to.eventually.be.deep.equal(response)
+    ]);
+  });
+
+});

--- a/tests/test-st2bot-setup.js
+++ b/tests/test-st2bot-setup.js
@@ -49,27 +49,32 @@ describe("stanley the StackStorm bot", function() {
 
       // Load script under test
       st2bot = require("../scripts/stackstorm");
-      commands_load_interval = st2bot(robot);
 
-      // Load help module
-      robot.loadFile(path.resolve('node_modules', 'hubot-help', 'src'), 'help.coffee');
+      st2bot(robot).then(function(result) {
+        commands_load_interval = result;
+        // Load help module
+        robot.loadFile(path.resolve('node_modules', 'hubot-help', 'src'), 'help.coffee');
 
-      user = robot.brain.userForId("1", {
-        name: "mocha",
-        room: "#mocha"
+        user = robot.brain.userForId("1", {
+          name: "mocha",
+          room: "#mocha"
+        });
+
+        adapter = robot.adapter;
+        done();
+      }).catch(function(err) {
+        done();
       });
-
-      adapter = robot.adapter;
-      done();
     });
 
     robot.run();
   });
 
-  after(function() {
+  after(function(done) {
     clearInterval(commands_load_interval);
     robot.server.close();
     robot.shutdown();
+    done();
   });
 
   it("responds when asked for help", function(done) {

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -72,7 +72,6 @@ describe('getExecutionIdFromMessage', function() {
 
   it('should return execution id on match', function() {
     var result = utils.getExecutionIdFromMessage(MOCK_MESSAGE);
-    console.log(result);
     expect(result).to.be.equal('55701c8b0640fd53cdf4f08');
   });
 });

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -79,7 +79,7 @@ describe('getExecutionIdFromMessage', function() {
 
 describe('parseUrl', function() {
   it('should correctly parse values', function() {
-    var result = utils.parseUrl('http://www.example.com/a')
+    var result = utils.parseUrl('http://www.example.com/a');
     expect(result['hostname']).to.be.equal('www.example.com');
     expect(result['protocol']).to.be.equal('http');
     expect(result['port']).to.be.equal(80);
@@ -87,21 +87,21 @@ describe('parseUrl', function() {
   });
 
   it('should correctly parrse ports', function() {
-    var result = utils.parseUrl('http://www.example.com:8080')
-      expect(result['port']).to.be.equal(8080);
+    var result = utils.parseUrl('http://www.example.com:8080');
+    expect(result['port']).to.be.equal(8080);
 
-    var result = utils.parseUrl('https://www.example.com:8181')
-      expect(result['port']).to.be.equal(8181);
+    result = utils.parseUrl('https://www.example.com:8181');
+    expect(result['port']).to.be.equal(8181);
   });
 
   it('should use default http port on port not specified', function() {
-    var result = utils.parseUrl('http://www.example.com/a')
+    var result = utils.parseUrl('http://www.example.com/a');
     expect(result['protocol']).to.be.equal('http');
     expect(result['port']).to.be.equal(80);
   });
 
   it('should use default https port on port not specified', function() {
-    var result = utils.parseUrl('https://www.example.com/a')
+    var result = utils.parseUrl('https://www.example.com/a');
     expect(result['protocol']).to.be.equal('https');
     expect(result['port']).to.be.equal(443);
   });


### PR DESCRIPTION
* With this change the authentication code is moved into a separate module. The modularization helps testability and also keep stackstorm.js sane.
* Added test cases for authentication and while working on tests cleaned up some previous tests also and/or fixed broken tests.
* Authentication is now a little resilient at bootstrap i.e. wait for the service to initialize before giving up.
* Failure to authenticate will no longer cause hubot to exit. An error is logged and hubot continues to work - this is to support deployments on existing hubot installs which seems like a common deployment pattern.
