### PR TITLE
Refactor formatter

### DIFF
--- a/lib/format_data.js
+++ b/lib/format_data.js
@@ -18,58 +18,78 @@ limitations under the License.
 "use strict";
 
 var _ = require('lodash'),
-    util = require('util'),
-    Table = require('cli-table');
+  util = require('util'),
+  utils = require('./utils.js');
 
-module.exports = function(data, formatType, logger) {
-  var tableFormatData = function(data, logger) {
-    if (!data) {
-      return "";
-    }
+var env = process.env;
 
-    data = JSON.parse(data);
-    var table = new Table({
-      style: {
-        head: [],
-        border: [],
-        compact: false
-      },
-      head: ['Property', 'Value']
-    });
-    _.forEach(data, function(v, k) {
-      table.push([k, v]);
-    });
-    return util.format('```\n%s```', table.toString());
-  };
+/*
+  SlackFormatter.
+*/
+function SlackFormatter(robot) {
+  this.robot = robot;
+}
 
-  var jsonFormatData = function(data, logger) {
-    if (!data) {
-      return "";
-    }
-    data = JSON.parse(data);
-    return util.format('```\n%s\n```', JSON.stringify(data, null, 4));
-  };
-
-  var basicFormatData = function(data, logger) {
-    if (!data) {
-      return "";
-    }
-    return util.format('```\n%s\n```', data);
-  };
-
-  var dataformatters = {
-    'table': tableFormatData,
-    'json': jsonFormatData,
-    'basic': basicFormatData
-  };
-
-  if (!formatType) {
-    formatType = 'basic';
+SlackFormatter.prototype.formatData = function(data) {
+  if (utils.isNull(data)) {
+    return "";
   }
+  return util.format('```\n%s\n```', data);
+};
 
-  if (!(formatType in dataformatters)) {
-    throw new Error(util.format('Formatter %s not supported.', formatType));
+SlackFormatter.prototype.formatRecepient = function(recepient) {
+  return recepient;
+};
+
+/*
+  HipChatFormatter.
+*/
+function HipChatFormatter(robot) {
+  this.robot = robot;
+}
+
+HipChatFormatter.prototype.formatData = function(data) {
+  if (utils.isNull(data)) {
+    return "";
   }
+  return data;
+};
 
-  return dataformatters[formatType](data, logger);
+HipChatFormatter.prototype.formatRecepient = function(recepient) {
+  var robot_name = env.HUBOT_HIPCHAT_JID.split("_")[0];
+  var hipchat_domain = env.HUBOT_HIPCHAT_JID.split("@")[1];
+  return util.format('%s_%s@%s', robot_name, recepient, hipchat_domain)
+};
+
+/*
+  DefaultFormatter.
+*/
+function DefaultFormatter(robot) {
+  this.robot = robot;
+}
+
+DefaultFormatter.prototype.formatData = function(data) {
+  if (utils.isNull(data)) {
+    return "";
+  }
+  return data;
+};
+
+DefaultFormatter.prototype.formatRecepient = function(recepient) {
+  return recepient;
+};
+
+var formatters = {
+  'slack': SlackFormatter,
+  'hipchat': HipChatFormatter,
+  'default': DefaultFormatter
+};
+
+module.exports.getFormatter = function(adapterName, robot) {
+  if (!(adapterName in formatters)) {
+    robot.logger.warning(
+      util.format('No supported formatter found for %s. Using DefaultFormatter.', adapterName));
+    adapterName = 'default';
+  }
+  return new formatters[adapterName](robot);
 };

--- a/lib/format_data.js
+++ b/lib/format_data.js
@@ -18,6 +18,7 @@ limitations under the License.
 "use strict";
 
 var _ = require('lodash'),
+  truncate = require('truncate'),
   util = require('util'),
   utils = require('./utils.js');
 
@@ -28,11 +29,17 @@ var env = process.env;
 */
 function SlackFormatter(robot) {
   this.robot = robot;
+
+  // Limit the size of a message.
+  this.truncate_length = env.ST2_MAX_MESSAGE_LENGTH;
 }
 
 SlackFormatter.prototype.formatData = function(data) {
   if (utils.isNull(data)) {
     return "";
+  }
+  if (this.truncate_length > 0) {
+    data = truncate(data, this.truncate_length);
   }
   return util.format('```\n%s\n```', data);
 };
@@ -52,13 +59,14 @@ HipChatFormatter.prototype.formatData = function(data) {
   if (utils.isNull(data)) {
     return "";
   }
+  // HipChat has "show more" capability in messages so no truncation.
   return data;
 };
 
 HipChatFormatter.prototype.formatRecepient = function(recepient) {
   var robot_name = env.HUBOT_HIPCHAT_JID.split("_")[0];
   var hipchat_domain = env.HUBOT_HIPCHAT_JID.split("@")[1];
-  return util.format('%s_%s@%s', robot_name, recepient, hipchat_domain)
+  return util.format('%s_%s@%s', robot_name, recepient, hipchat_domain);
 };
 
 /*
@@ -66,11 +74,17 @@ HipChatFormatter.prototype.formatRecepient = function(recepient) {
 */
 function DefaultFormatter(robot) {
   this.robot = robot;
+
+  // Limit the size of a message.
+  this.truncate_length = env.ST2_MAX_MESSAGE_LENGTH;
 }
 
 DefaultFormatter.prototype.formatData = function(data) {
   if (utils.isNull(data)) {
     return "";
+  }
+  if (this.truncate_length > 0) {
+    data = truncate(data, this.truncate_length);
   }
   return data;
 };

--- a/lib/format_data.js
+++ b/lib/format_data.js
@@ -48,6 +48,14 @@ SlackFormatter.prototype.formatRecepient = function(recepient) {
   return recepient;
 };
 
+SlackFormatter.prototype.normalizeCommand = function(command) {
+  // replace left double quote with regular quote
+  command = command.replace('\u201c', '\u0022');
+  // replace right double quote with regular quote
+  command = command.replace('\u201d', '\u0022');
+  return command;
+};
+
 /*
   HipChatFormatter.
 */
@@ -60,7 +68,7 @@ HipChatFormatter.prototype.formatData = function(data) {
     return "";
   }
   // HipChat has "show more" capability in messages so no truncation.
-  return data;
+  return '/code ' + data;
 };
 
 HipChatFormatter.prototype.formatRecepient = function(recepient) {
@@ -68,6 +76,10 @@ HipChatFormatter.prototype.formatRecepient = function(recepient) {
   // harcode for now. This most likely requires some investiagtion.
   var hipchat_domain = 'conf.hipchat.com';
   return util.format('%s_%s@%s', robot_name, recepient, hipchat_domain);
+};
+
+HipChatFormatter.prototype.normalizeCommand = function(command) {
+  return command;
 };
 
 /*
@@ -92,6 +104,10 @@ DefaultFormatter.prototype.formatData = function(data) {
 
 DefaultFormatter.prototype.formatRecepient = function(recepient) {
   return recepient;
+};
+
+DefaultFormatter.prototype.normalizeCommand = function(command) {
+  return command;
 };
 
 var formatters = {

--- a/lib/format_data.js
+++ b/lib/format_data.js
@@ -65,7 +65,8 @@ HipChatFormatter.prototype.formatData = function(data) {
 
 HipChatFormatter.prototype.formatRecepient = function(recepient) {
   var robot_name = env.HUBOT_HIPCHAT_JID.split("_")[0];
-  var hipchat_domain = env.HUBOT_HIPCHAT_JID.split("@")[1];
+  // harcode for now. This most likely requires some investiagtion.
+  var hipchat_domain = 'conf.hipchat.com';
   return util.format('%s_%s@%s', robot_name, recepient, hipchat_domain);
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,9 +15,9 @@
  limitations under the License.
  */
 
-var url = require('url');
-var util = require('util');
-var env = process.env;
+var url = require('url'),
+  util = require('util'),
+  env = process.env;
 
 var _ = require('lodash');
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lodash": "~3.8.0",
     "cli-table": "<=1.0.0",
     "rsvp": "3.0.14",
-    "st2client": "~0.3.3"
+    "st2client": "~0.3.3",
+    "truncate": "^1.0.4"
   },
   "peerDependencies": {
     "hubot": "2.x"

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -58,6 +58,9 @@ env.ST2_AUTH_URL = env.ST2_AUTH_URL || null;
 // Command reload interval in seconds
 env.ST2_COMMANDS_RELOAD_INTERVAL = parseInt(env.ST2_COMMANDS_RELOAD_INTERVAL || 120, 10);
 
+// Cap message length to a certain number of characters.
+env.ST2_MAX_MESSAGE_LENGTH = parseInt(env.ST2_MAX_MESSAGE_LENGTH || 500, 10);
+
 // Constants
 // Fun human-friendly commands. Use %s for payload output.
 var START_MESSAGES = [
@@ -87,7 +90,7 @@ module.exports = function(robot) {
   var command_factory = new CommandFactory(robot);
 
   // formatter to manage per adapter message formatting.
-  var formatter = formatData.getFormatter(robot.adapterName, robot)
+  var formatter = formatData.getFormatter(robot.adapterName, robot);
 
   var loadCommands = function() {
     var request;
@@ -226,7 +229,7 @@ module.exports = function(robot) {
       } else {
         recipient = data.channel;
       }
-      recepient = formatter.formatRecepient(recepient);
+      recipient = formatter.formatRecepient(recipient);
 
       execution_id = utils.getExecutionIdFromMessage(message);
       history_url = utils.getExecutionHistoryUrl(execution_id);

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -86,6 +86,9 @@ module.exports = function(robot) {
   // factory to manage commands
   var command_factory = new CommandFactory(robot);
 
+  // formatter to manage per adapter message formatting.
+  var formatter = formatData.getFormatter(robot.adapterName, robot)
+
   var loadCommands = function() {
     var request;
 
@@ -210,12 +213,7 @@ module.exports = function(robot) {
       } else {
         data = req.body;
       }
-      if (robot.adapterName === "hipchat") {
-        message = data.message;
-      }
-      else {
-        message = formatData(data.message, '', robot.logger);
-      }
+      message = formatter.formatData(data.message);
 
       // PM user, notify user, or tell channel
       if (data.user) {
@@ -228,18 +226,13 @@ module.exports = function(robot) {
       } else {
         recipient = data.channel;
       }
+      recepient = formatter.formatRecepient(recepient);
 
       execution_id = utils.getExecutionIdFromMessage(message);
       history_url = utils.getExecutionHistoryUrl(execution_id);
 
       if (history_url) {
         message += util.format('\n Execution details available at: %s', history_url);
-      }
-
-      if (robot.adapterName === "hipchat" ) {
-        robot.logger.info('Using adapter ' + robot.adapterName + '. Modifying the recipient.');
-        var robot_name = env.HUBOT_HIPCHAT_JID.split("_", 1);
-        recipient = robot_name + "_" + recipient + "@conf.hipchat.com";
       }
 
       robot.messageRoom(recipient, message);

--- a/tests/dummy-robot.js
+++ b/tests/dummy-robot.js
@@ -30,11 +30,11 @@ function Logger(enabled) {
     this.log.error(msg);
   };
 
-  this.warn = function(msg) {
+  this.warning = function(msg) {
     if (!this.enabled) {
       return;
     }
-    this.log.warn(msg);
+    this.log.warning(msg);
   };
 
   this.info = function(msg) {

--- a/tests/test-formatdata.js
+++ b/tests/test-formatdata.js
@@ -62,6 +62,13 @@ describe('SlackFormatter', function() {
     expect(o).to.be.an('string');
     expect(o).to.equal('Estee');
   });
+
+  it('should normalize command', function() {
+    var formatter = formatData.getFormatter(adapterName, null);
+    var o = formatter.normalizeCommand('run local \u201cuname -a"');
+    expect(o).to.be.an('string');
+    expect(o).to.equal('run local "uname -a"');
+  });
 });
 
 describe('HipChatFormatter', function() {
@@ -87,6 +94,13 @@ describe('HipChatFormatter', function() {
     var o = formatter.formatRecepient('Estee');
     expect(o).to.be.an('string');
     expect(o).to.equal('234x_Estee@conf.hipchat.com');
+  });
+
+  it('should normalize command', function() {
+    var formatter = formatData.getFormatter(adapterName, null);
+    var o = formatter.normalizeCommand('run local "uname -a"');
+    expect(o).to.be.an('string');
+    expect(o).to.equal('run local "uname -a"');
   });
 });
 
@@ -124,5 +138,12 @@ describe('DefaultFormatter', function() {
     var o = formatter.formatRecepient('Estee');
     expect(o).to.be.an('string');
     expect(o).to.equal('Estee');
+  });
+
+  it('should normalize command', function() {
+    var formatter = formatData.getFormatter(adapterName, robot);
+    var o = formatter.normalizeCommand('run local "uname -a"');
+    expect(o).to.be.an('string');
+    expect(o).to.equal('run local "uname -a"');
   });
 });

--- a/tests/test-formatdata.js
+++ b/tests/test-formatdata.js
@@ -20,76 +20,84 @@ limitations under the License.
 "use strict";
 
 var chai = require('chai'),
-  assert = chai.assert,
   expect = chai.expect,
-  formatdata = require('../lib/format_data.js');
+  env = process.env,
+  formatData = require('../lib/format_data.js'),
+  DummyRobot = require('./dummy-robot.js');
 
-describe('unknownFormatData', function() {
-  it('should throw an exception', function() {
-    assert.throws(function() {
-      formatdata('', 'X', null);
-    }, Error, 'Formatter X not supported.');
-  });
+describe('SlackFormatter', function() {
+  var adapterName = 'slack';
 
-  it('should pick basicFormatdata on null', function() {
-    var o = formatdata('DATA', null, null);
+  it('should create a snippet for non-empty', function() {
+    var formatter = formatData.getFormatter(adapterName, null);
+    var o = formatter.formatData('DATA', 'slack', null);
     expect(o).to.be.an('string');
     expect(o).to.equal('```\nDATA\n```');
   });
 
-  it('should pick basicFormatdata on empty', function() {
-    var o = formatdata('DATA', '', null);
-    expect(o).to.be.an('string');
-    expect(o).to.equal('```\nDATA\n```');
-  });
-});
-
-
-describe('tableFormatdata', function() {
-  var format = 'table';
-
-  it('should do nothing for empty data', function() {
-    var o = formatdata('', format, null);
+  it('should be an empty string for empty', function() {
+    var formatter = formatData.getFormatter(adapterName, null);
+    var o = formatter.formatData('', null);
     expect(o).to.be.an('string');
     expect(o).to.equal('');
   });
 
-  it('should create the right table format', function() {
-    var o = formatdata("{\"a\": 1}", format, null);
+  it('should echo back recepient', function() {
+    var formatter = formatData.getFormatter(adapterName, null);
+    var o = formatter.formatRecepient('Estee');
     expect(o).to.be.an('string');
-    expect(o).to.equal('```\n┌──────────┬───────┐\n│ Property │ Value │\n├──────────┼───────┤\n│ a        │ 1     │\n└──────────┴───────┘```');
+    expect(o).to.equal('Estee');
   });
 });
 
-describe('jsonFormatdata', function() {
-  var format = 'json';
+describe('HipChatFormatter', function() {
+  var adapterName = 'hipchat';
 
-  it('should do nothing for empty data', function() {
-    var o = formatdata('', format, null);
+  it('should echo back for non-empty', function() {
+    var formatter = formatData.getFormatter(adapterName, null);
+    var o = formatter.formatData('DATA', null);
+    expect(o).to.be.an('string');
+    expect(o).to.equal('DATA');
+  });
+
+  it('should be an empty string for empty', function() {
+    var formatter = formatData.getFormatter(adapterName, null);
+    var o = formatter.formatData('', null);
     expect(o).to.be.an('string');
     expect(o).to.equal('');
   });
 
-  it('should create the right json format', function() {
-    var o = formatdata("{\"a\": 1}", format, null);
+  it('should correctly format recepient', function() {
+    var formatter = formatData.getFormatter(adapterName, null);
+    env.HUBOT_HIPCHAT_JID = '234x_y234@conf.hipchat.com';
+    var o = formatter.formatRecepient('Estee');
     expect(o).to.be.an('string');
-    // Not a big fan of this test
-    expect(o).to.equal('```\n{\n    \"a\": 1\n}\n```');
+    expect(o).to.equal('234x_Estee@conf.hipchat.com');
   });
 });
 
-describe('basicFormatdata', function() {
-  var format = 'basic';
+describe('DefaultFormatter', function() {
+  var adapterName = 'unknown';
+  var robot = new DummyRobot('dummy', false);
 
-  it('should do nothing for empty data', function() {
-    var o = formatdata('', format, null);
+  it('should create a snippet for non-empty', function() {
+    var formatter = formatData.getFormatter(adapterName, robot);
+    var o = formatter.formatData('DATA', null);
+    expect(o).to.be.an('string');
+    expect(o).to.equal('DATA');
+  });
+
+  it('should be an empty string for empty', function() {
+    var formatter = formatData.getFormatter(adapterName, robot);
+    var o = formatter.formatData('', null);
     expect(o).to.be.an('string');
     expect(o).to.equal('');
   });
 
-  it('should create the right basic format', function() {
-    var o = formatdata('DATA', format, null);
+  it('should echo back recepient', function() {
+    var formatter = formatData.getFormatter(adapterName, robot);
+    var o = formatter.formatRecepient('Estee');
     expect(o).to.be.an('string');
-    expect(o).to.equal('```\nDATA\n```');
+    expect(o).to.equal('Estee');
   });
 });

--- a/tests/test-formatdata.js
+++ b/tests/test-formatdata.js
@@ -71,7 +71,7 @@ describe('HipChatFormatter', function() {
     var formatter = formatData.getFormatter(adapterName, null);
     var o = formatter.formatData('DATA', null);
     expect(o).to.be.an('string');
-    expect(o).to.equal('DATA');
+    expect(o).to.equal('/code DATA');
   });
 
   it('should be an empty string for empty', function() {

--- a/tests/test-formatdata.js
+++ b/tests/test-formatdata.js
@@ -25,14 +25,28 @@ var chai = require('chai'),
   formatData = require('../lib/format_data.js'),
   DummyRobot = require('./dummy-robot.js');
 
+env.ST2_MAX_MESSAGE_LENGTH = 500;
+
 describe('SlackFormatter', function() {
   var adapterName = 'slack';
 
   it('should create a snippet for non-empty', function() {
     var formatter = formatData.getFormatter(adapterName, null);
-    var o = formatter.formatData('DATA', 'slack', null);
+    var o = formatter.formatData('DATA', null);
     expect(o).to.be.an('string');
     expect(o).to.equal('```\nDATA\n```');
+  });
+
+  it('should truncate text more than a certain length', function() {
+    var org_max_length = env.ST2_MAX_MESSAGE_LENGTH;
+    env.ST2_MAX_MESSAGE_LENGTH = 10;
+    var formatter = formatData.getFormatter(adapterName, null);
+    var o = formatter.formatData('abcd efgh ijklm', null);
+    env.ST2_MAX_MESSAGE_LENGTH = org_max_length;
+
+    expect(o).to.be.an('string');
+    expect(o).to.equal('```\nabcd efgh ...\n```');
+
   });
 
   it('should be an empty string for empty', function() {
@@ -85,6 +99,17 @@ describe('DefaultFormatter', function() {
     var o = formatter.formatData('DATA', null);
     expect(o).to.be.an('string');
     expect(o).to.equal('DATA');
+  });
+
+  it('should truncate text more than a certain length', function() {
+    var org_max_length = env.ST2_MAX_MESSAGE_LENGTH;
+    env.ST2_MAX_MESSAGE_LENGTH = 10;
+    var formatter = formatData.getFormatter(adapterName, robot);
+    var o = formatter.formatData('abcd efgh ijklm', null);
+    env.ST2_MAX_MESSAGE_LENGTH = org_max_length;
+
+    expect(o).to.be.an('string');
+    expect(o).to.equal('abcd efgh ...');
   });
 
   it('should be an empty string for empty', function() {

--- a/tests/test-st2bot-setup.js
+++ b/tests/test-st2bot-setup.js
@@ -45,7 +45,7 @@ describe("stanley the StackStorm bot", function() {
     // Hack. Need a better solution than stubbing out methods.
     if (disableLogger) {
       robot.logger.error = controlledLogger;
-      robot.logger.warn = controlledLogger;
+      robot.logger.warning = controlledLogger;
       robot.logger.info = controlledLogger;
       robot.logger.debug = controlledLogger;
     }


### PR DESCRIPTION
### Changes

Large PR with many different changes. Which got inter-mingled with each other and I lost patience to detangle the mess.

* Moved all adapter specific code into specific modules
* Dropped all tableformat and jsonformat code since it is not used anyway
* Move recipient formatting to format module as well so that adapter specific is hidden away
* Truncate message text at 500 characters. (value is configurable via environment variables)
* Hardcode the right hipchat domain.
* Slack replace \u0022 with \u201c when it notices a left quote mark. This breaks
  the command parsing on the back end. So something like run local "uanme -a" would
  not work. Normalizing brings back the functionality in slack. Ofcourse the
  downside to the approach is if a user legitemately would like to use left double
  quote mark then that would blow-up.
* Special formatting directive for hipchat.
* To have control over what get truncate and what does not send out response
  to slack as multiple messages. This provide some flexibility in message
  formatting.

### Notes on testing
Using the `slack` and `hipchat` adapters tested the following commands -
* `!run local date` - Basic test
* `!run local "uname -a"` - Issue with quotes
* `!run local "cat /tmp/Makefile"` - To validate truncation