### PR TITLE
Document ST2_MAX_MESSAGE_LENGTH

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ specified when running hubot:
 * `ST2_AUTH_URL` - URL to the StackStorm Auth API (optional).
 * `ST2_COMMANDS_RELOAD_INTERVAL` - How often the list of available commands
   should be reloaded. Defaults to every 120 seconds (optional).
+* `ST2_MAX_MESSAGE_LENGTH` - Message truncation to preserve chat context. Default is 500 characters of length. 0 means no limit (optional).
 
 Note: ``ST2_CHANNEL`` environment variable mentioned below should only be
 specified if you modified the rule which comes with a ``hubot`` pack to use a


### PR DESCRIPTION
Was surprised to see that messages are truncated now.

BTW, are you sure they should be truncated to `500` by default?
Personally I would always set it to `0` for no limit. Feel like it should be default behavior with optional possibility to cut those messages.
Especially because there wasn't such limit before.

![ex](http://i.imgur.com/Ggxl163.png)

