### PR TITLE
regex not matching properly

### DIFF
--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -46,8 +46,8 @@ CommandFactory.prototype.getRegexForFormatString = function(format) {
   // number of key=value pairs at the end of the string
   // Format parameters with default value {{param=value}} are allowed to
   // be skipped.
-  regex_str = format.replace(/\s+{{\w+\s*=.+?}}/g, '(\\s+)?(.*?)');
-  regex_str = regex_str.replace(/{{.+?}}/g, '(.+?)');
+  regex_str = format.replace(/\s+{{\w+\s*=.+?}}/g, '(\\s+)?([^\\s]*?)');
+  regex_str = regex_str.replace(/{{.+?}}/g, '([^\\s]+?)');
   regex = new RegExp(regex_str + '(\\s+)?(\\s?(\\w+)=(\\w+)){0,}' + '$');
 
   return regex;


### PR DESCRIPTION
The regex was maching on any character "." which included spaces.  changed to be "not space" ^\s