### PR TITLE
fixed regex on command factory w/tests

### DIFF
--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -46,8 +46,8 @@ CommandFactory.prototype.getRegexForFormatString = function(format) {
   // number of key=value pairs at the end of the string
   // Format parameters with default value {{param=value}} are allowed to
   // be skipped.
-  regex_str = format.replace(/\s+{{\w+\s*=.+?}}/g, '(\\s+)?(.*?)');
-  regex_str = regex_str.replace(/{{.+?}}/g, '(.+?)');
+  regex_str = format.replace(/\s+{{\w+\s*=.+?}}/g, '(\\s+)?([^\\s]*?)');
+  regex_str = regex_str.replace(/{{.+?}}/g, '([^\\s]+?)');
   regex = new RegExp(regex_str + '(\\s+)?(\\s?(\\w+)=(\\w+)){0,}' + '$');
 
   return regex;

--- a/tests/fixtures/aliases.json
+++ b/tests/fixtures/aliases.json
@@ -17,4 +17,11 @@
   "formats": [
     "alias3 fmt1 {{param1}} {{param2}} {{param3=default}} trailing words"
   ]
+}, {
+  "name": "alias4",
+  "description": "alias4",
+  "formats": [
+    "alias4 fmt1 {{param1}}",
+    "alias4 fmt1 {{param1}} word {{param2}}"
+  ]
 }]

--- a/tests/test-command-factory.js
+++ b/tests/test-command-factory.js
@@ -120,6 +120,35 @@ describe('command factory', function() {
     match = command_factory.getMatchingCommand('alias2 fmt2 value1 some more words');
     expect(match[0]).to.equal('alias2');
     expect(match[1]).to.equal('alias2 fmt2 {{param1}} some more words');
+
+
+  });
+
+  it('should match various command literals even if the beginning format seems to match a shorter alias', function() {
+    var command_factory, alias, match, alias_format, idx_f;
+
+    command_factory = getCleanCommandFactory();
+    alias = ALIAS_FIXTURES[3];
+
+    for (idx_f = 0; idx_f < alias.formats.length; idx_f++) {
+      alias_format = alias.formats[idx_f];
+      command_factory.addCommand(
+        formatCommand(null, alias.name, alias_format, alias.description),
+        alias.name,
+        alias_format,
+        alias);
+    }
+
+    expect(command_factory.robot.commands).to.have.length(2);
+
+    match = command_factory.getMatchingCommand('alias4 fmt1 value1');
+    expect(match[0]).to.equal('alias4');
+    expect(match[1]).to.equal('alias4 fmt1 {{param1}}');
+
+    match = command_factory.getMatchingCommand('alias4 fmt1 value1 word value2');
+    expect(match[0]).to.equal('alias4');
+    expect(match[1]).to.equal('alias4 fmt1 {{param1}} word {{param2}}');
+
   });
 
 });


### PR DESCRIPTION
cancel the previous pull request.  This one updates the test fixtures with a new test for the case when two formats match at the beginning.  e.g

alias4 fmt1 value1
alias4 fmt1 value2 word value2