### PR TITLE
Better error reporting if we fail to load the commands because of an exception

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,16 @@
+0.2.2
+-----
+
+* Log a better error message if we fail to load the commands because of the StackStorm API unavailability.
+
 0.2.1
 -----
+
 * Switched to use StackStorm API v1 instead of exp.
 
 0.2.0
 -----
+
 * Preserve user supplied casing for chat literals. (bug-fix)
 * Refactor formatting code to handle various adapter better. Tested support for
   slack, hubot and xmpp.
@@ -18,7 +25,8 @@
 -----
 * Support Hipchat channel type and message format (@Itxaka)
 * hubot-stackstorm does not cause hubot to quit on authentication failure.
-* Authentication code is resilient to unavailability or StackStorm service. Will retry a configurable number of times.
+* Authentication code is resilient to unavailability or StackStorm service. Will retry a
+  configurable number of times.
 
 0.1.1
 -----

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-stackstorm",
   "description": "A hubot plugin for integrating with StackStorm event-driven infrastructure automation platform.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "StackStorm, Inc. <info@stackstorm.com>",
   "license": "Apache-2.0",
   "keywords": [

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -106,11 +106,11 @@ module.exports = function(robot) {
 
     request.get()(
       function(err, resp, body) {
-        var parsed_body, success, error_msg_prefix;
+        var parsed_body, success, error_msg;
 
-        error_msg_prefix = 'Failed to retrieve commands from ' + env.ST2_API + ': ';
         if (err) {
-          robot.logger.error(error_msg_prefix + err.toString());
+          error_msg = 'Failed to retrieve commands from "%s": %s';
+          robot.logger.error(util.format(error_msg, env.ST2_API, err.toString()));
           return;
         }
 
@@ -122,7 +122,8 @@ module.exports = function(robot) {
         }
 
         if (!success) {
-          robot.logger.error(body + err.toString());
+          error_msg = 'Failed to retrieve commands from "%s": %s';
+          robot.logger.error(util.format(error_msg, env.ST2_API, body));
           return;
         }
 

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -106,7 +106,13 @@ module.exports = function(robot) {
 
     request.get()(
       function(err, resp, body) {
-        var parsed_body, success;
+        var parsed_body, success, error_msg_prefix;
+
+        error_msg_prefix = 'Failed to retrieve commands from ' + env.ST2_API + ': ';
+        if (err) {
+          robot.logger.error(error_msg_prefix + err.toString());
+          return;
+        }
 
         parsed_body = JSON.parse(body);
         if (!_.isArray(parsed_body)) {
@@ -116,7 +122,7 @@ module.exports = function(robot) {
         }
 
         if (!success) {
-          robot.logger.error('Failed to retrieve commands: ' + body);
+          robot.logger.error(body + err.toString());
           return;
         }
 


### PR DESCRIPTION
Previously, if an exception was thrown (e.g. connection refused - API is offline, connection timeout, etc.). we wouldn't correctly log the reason for the loading failure (the error would just say null).