### PR TITLE
Support white space

### DIFF
--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -47,7 +47,7 @@ CommandFactory.prototype.getRegexForFormatString = function(format) {
   // Format parameters with default value {{param=value}} are allowed to
   // be skipped.
   regex_str = format.replace(/\s+{{\w+\s*=.+?}}/g, '(\\s+)?([^\\s]*?)');
-  regex_str = regex_str.replace(/{{.+?}}/g, '([^\\s]+?)');
+  regex_str = regex_str.replace(/{{.+?}}/g, '([\\S\\s]+?)');
   regex = new RegExp(regex_str + '(\\s+)?(\\s?(\\w+)=(\\w+)){0,}' + '$');
 
   return regex;
@@ -107,7 +107,6 @@ CommandFactory.prototype.getMatchingCommand = function(command) {
   for (i = 0; i < format_strings.length; i++) {
     format_string = format_strings[i];
     regex = this.st2_commands_regex_map[format_string];
-
     if (regex.test(command)) {
       command_name = this.st2_commands_format_map[format_string].name;
       return [command_name, format_string];

--- a/tests/fixtures/aliases.json
+++ b/tests/fixtures/aliases.json
@@ -21,7 +21,7 @@
   "name": "alias4",
   "description": "alias4",
   "formats": [
-    "alias4 fmt1 {{param1}}",
-    "alias4 fmt1 {{param1}} word {{param2}}"
+    "alias4 fmt1 {{param1}} word {{param2}}",
+    "alias4 fmt1 {{param1}}"
   ]
 }]

--- a/tests/test-command-factory.js
+++ b/tests/test-command-factory.js
@@ -96,6 +96,25 @@ describe('command factory', function() {
 
   });
 
+  it('should match command literals with blank spaces in values', function() {
+    var command_factory, alias, match;
+
+    command_factory = getCleanCommandFactory();
+    alias = ALIAS_FIXTURES[2];
+
+    command_factory.addCommand(
+      formatCommand(null, alias.name, alias.formats[0], alias.description),
+      alias.name,
+      alias.formats[0],
+      alias);
+
+    expect(command_factory.robot.commands).to.have.length(1);
+
+    match = command_factory.getMatchingCommand('alias3 fmt1 "blank space" no_blank_space trailing words');
+    expect(match[0]).to.equal('alias3');
+
+  });
+
   it('should match command literals for various formats of an alias', function() {
     var command_factory, alias, alias_format, match, idx_f;
 
@@ -120,7 +139,6 @@ describe('command factory', function() {
     match = command_factory.getMatchingCommand('alias2 fmt2 value1 some more words');
     expect(match[0]).to.equal('alias2');
     expect(match[1]).to.equal('alias2 fmt2 {{param1}} some more words');
-
 
   });
 


### PR DESCRIPTION
* Commands literals with quoted parameters allow blank spaces. Support
  for blank spaces added by delicately modifying the regexes.

Note : the ordering change in alias fixture is to require the more restrictive format to be placed higher.