### PR TITLE
Use slack attachment to display results

### DIFF
--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -254,8 +254,17 @@ module.exports = function(robot) {
       if (execution_details) {
         args.push(util.format('Execution details available at: %s', execution_details));
       }
-
-      robot.messageRoom.apply(robot, args);
+      robot.emit('slack-attachment', {
+        channel: recipient,
+        content: {
+          color: "c0c0c0",
+          title: "Execution Details",
+          title_link: execution_details,
+          text: formatter.formatData(data.message),
+          "mrkdwn_in": ["text", "pretext"]
+        }
+      });
+      //robot.messageRoom.apply(robot, args);
       res.send('{"status": "completed", "msg": "Message posted successfully"}');
     } catch (e) {
       robot.logger.error("Unable to decode JSON: " + e);

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -256,10 +256,14 @@ module.exports = function(robot) {
       }
       
       if (robot.adapterName == 'slack') {
+        var attachment_color = 'dfdfdf';
+        if (data.message.indexOf("status : failed") > -1) {
+          attachment_color = 'danger';
+        }
         robot.emit('slack-attachment', {
           channel: recipient,
           content: {
-            color: "c0c0c0",
+            color: attachment_color,
             title: "Execution Details",
             title_link: execution_details,
             text: formatter.formatData(data.message),

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -254,17 +254,21 @@ module.exports = function(robot) {
       if (execution_details) {
         args.push(util.format('Execution details available at: %s', execution_details));
       }
-      robot.emit('slack-attachment', {
-        channel: recipient,
-        content: {
-          color: "c0c0c0",
-          title: "Execution Details",
-          title_link: execution_details,
-          text: formatter.formatData(data.message),
-          "mrkdwn_in": ["text", "pretext"]
-        }
-      });
-      //robot.messageRoom.apply(robot, args);
+      
+      if (robot.adapterName == 'slack') {
+        robot.emit('slack-attachment', {
+          channel: recipient,
+          content: {
+            color: "c0c0c0",
+            title: "Execution Details",
+            title_link: execution_details,
+            text: formatter.formatData(data.message),
+            "mrkdwn_in": ["text", "pretext"]
+          }
+        });
+      } else {
+        robot.messageRoom.apply(robot, args);
+      }
       res.send('{"status": "completed", "msg": "Message posted successfully"}');
     } catch (e) {
       robot.logger.error("Unable to decode JSON: " + e);


### PR DESCRIPTION
![slack attachment](http://i.imgur.com/56gb4ir.png "Result in attachments")

My chat ops returns are quite big so I wanted to have the results in the attachment.
It turns red for failures and there's the link to execution details.

I want to also change the initial message when an alias  is executed, let me know what you think