### PR TITLE
Option for the colors and putting back the username when not a whisper

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ specified when running hubot:
 * `ST2_COMMANDS_RELOAD_INTERVAL` - How often the list of available commands
   should be reloaded. Defaults to every 120 seconds (optional).
 * `ST2_MAX_MESSAGE_LENGTH` - Message truncation to preserve chat context. Default is 500 characters of length. 0 means no limit (optional).
+* `ST2_SLACK_SUCCESS_COLOR` - Slack attachement color for success, can either be one of good, warning, danger, or any hex color code (optional).
+* `ST2_SLACK_FAIL_COLOR` - Slack attachement color for failures either be one of good, warning, danger, or any hex color code (optional).
 
 Note: ``ST2_ROUTE`` environment variable mentioned below should only be
 specified if you modified the rule which comes with a ``hubot`` pack to use a

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -52,6 +52,10 @@ env.ST2_WEBUI_URL = env.ST2_WEBUI_URL || null;
 env.ST2_AUTH_USERNAME = env.ST2_AUTH_USERNAME || null;
 env.ST2_AUTH_PASSWORD = env.ST2_AUTH_PASSWORD || null;
 
+// slack attachment colors
+env.ST2_SLACK_SUCCESS_COLOR = env.ST2_SLACK_SUCCESS_COLOR || 'dfdfdf';
+env.ST2_SLACK_FAIL_COLOR = env.ST2_SLACK_FAIL_COLOR || 'danger';
+
 // Optional, if not provided, we infer it from the API URL
 env.ST2_AUTH_URL = env.ST2_AUTH_URL || null;
 
@@ -254,17 +258,22 @@ module.exports = function(robot) {
       if (execution_details) {
         args.push(util.format('Execution details available at: %s', execution_details));
       }
-      
+
       if (robot.adapterName == 'slack') {
-        var attachment_color = 'dfdfdf';
+        var attachment_color = env.ST2_SLACK_SUCCESS_COLOR;
         if (data.message.indexOf("status : failed") > -1) {
-          attachment_color = 'danger';
+          attachment_color = env.ST2_SLACK_FAIL_COLOR;
+        }
+        var text = "";
+        if (data.whisper != true) {
+          text = util.format('%s :', data.user);
         }
         robot.emit('slack-attachment', {
           channel: recipient,
+          text: text,
           content: {
             color: attachment_color,
-            title: "Execution Details",
+            title: "Execution " + execution_id,
             title_link: execution_details,
             text: formatter.formatData(data.message),
             "mrkdwn_in": ["text", "pretext"]


### PR DESCRIPTION
![slack](http://i.imgur.com/RtMYU9G.png "Different color, username")

Added options for the slack attachement colors and I put back the username in the message