### PR TITLE
Refactor message format into adapter specific classes

### DIFF
--- a/lib/format_data.js
+++ b/lib/format_data.js
@@ -29,19 +29,15 @@ var env = process.env;
 */
 function SlackFormatter(robot) {
   this.robot = robot;
-
-  // Limit the size of a message.
-  this.truncate_length = env.ST2_MAX_MESSAGE_LENGTH;
 }
 
 SlackFormatter.prototype.formatData = function(data) {
   if (utils.isNull(data)) {
     return "";
   }
-  if (this.truncate_length > 0) {
-    data = truncate(data, this.truncate_length);
-  }
-  return util.format('```\n%s\n```', data);
+  // For slack we do not truncate or format the result. This is because
+  // data is posted to slack as a message attachment.
+  return data;
 };
 
 SlackFormatter.prototype.formatRecepient = function(recepient) {

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -1,0 +1,107 @@
+/*
+ Licensed to the StackStorm, Inc ('StackStorm') under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+"use strict";
+
+/*
+  SlackDataPostHandler.
+*/
+function SlackDataPostHandler(robot) {
+  this.robot = robot;
+}
+
+SlackDataPostHandler.prototype.postData = function(data) {
+  // Some common properties.
+  execution_id = utils.getExecutionIdFromMessage(data.message);
+  execution_details = utils.getExecutionHistoryUrl(execution_id);
+  if (!execution_details) {
+    execution_details = utils.getExecutionCLICommand(execution_id);
+  }
+  var attachment_color = env.ST2_SLACK_SUCCESS_COLOR;
+  if (data.message.indexOf("status : failed") > -1) {
+    attachment_color = env.ST2_SLACK_FAIL_COLOR;
+  }
+  var text = "";
+  // PM user, notify user, or tell channel
+  if (data.whisper != true) {
+    text = util.format('%s :', data.user);
+  }
+  robot.emit('slack-attachment', {
+    channel: recipient,
+    text: text,
+    content: {
+      color: attachment_color,
+      title: "Execution " + execution_id,
+      title_link: execution_details,
+      text: formatter.formatData(data.message),
+      "mrkdwn_in": ["text", "pretext"]
+    }
+  });
+}
+
+/*
+  DefaultDataPostHandler.
+*/
+function DefaultFormatter(robot) {
+  this.robot = robot;
+}
+
+DefaultFormatter.prototype.postData = function(data) {
+  args = [];
+  // PM user, notify user, or tell channel
+  if (data.user) {
+    if (data.whisper === true) {
+      recipient = data.user;
+    } else {
+      recipient = data.channel;
+      // message = util.format('%s :\n%s', data.user, message);
+      args.push(util.format('%s :', data.user));
+    }
+  } else {
+    recipient = data.channel;
+  }
+  recipient = formatter.formatRecepient(recipient);
+  args.unshift(recipient);
+
+  args.push(formatter.formatData(data.message));
+
+  execution_id = utils.getExecutionIdFromMessage(data.message);
+  execution_details = utils.getExecutionHistoryUrl(execution_id);
+  if (!execution_details) {
+    execution_details = utils.getExecutionCLICommand(execution_id);
+  }
+
+  if (execution_details) {
+    args.push(util.format('Execution details available at: %s', execution_details));
+  }
+
+  robot.messageRoom.apply(robot, args);
+}
+
+var dataPostHandlers = {
+  'slack': SlackDataPostHandler,
+  'default': DefaultFormatter
+};
+
+module.exports.getDataPostHandler = function(adapterName, robot) {
+  if (!(adapterName in dataPostHandlers)) {
+    robot.logger.warning(
+      util.format('No supported formatter found for %s. Using DefaultFormatter.', adapterName));
+    adapterName = 'default';
+  }
+  return new dataPostHandlers[adapterName](robot);
+};

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -68,8 +68,9 @@ SlackDataPostHandler.prototype.postData = function(data) {
 /*
   DefaultDataPostHandler.
 */
-function DefaultFormatter(robot) {
+function DefaultFormatter(robot, formatter) {
   this.robot = robot;
+  this.formatter = formatter;
 }
 
 DefaultFormatter.prototype.postData = function(data) {
@@ -78,11 +79,10 @@ DefaultFormatter.prototype.postData = function(data) {
   args = [];
   // PM user, notify user, or tell channel
   if (data.user) {
-    if (data.whisper === true) {
+    if (data.whisper) {
       recipient = data.user;
     } else {
       recipient = data.channel;
-      // message = util.format('%s :\n%s', data.user, message);
       args.push(util.format('%s :', data.user));
     }
   } else {

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -17,21 +17,33 @@ limitations under the License.
 
 "use strict";
 
+var env = process.env,
+  util = require('util'),
+  utils = require('./utils.js');
+
 /*
   SlackDataPostHandler.
 */
-function SlackDataPostHandler(robot) {
+function SlackDataPostHandler(robot, formatter) {
   this.robot = robot;
+  this.formatter = formatter;
 }
 
 SlackDataPostHandler.prototype.postData = function(data) {
+  var recipient, execution_id, execution_details, attachment_color;
+
+  if (data.user && data.whisper) {
+    recipient = data.user;
+  } else {
+    recipient = data.channel;
+  }
   // Some common properties.
   execution_id = utils.getExecutionIdFromMessage(data.message);
   execution_details = utils.getExecutionHistoryUrl(execution_id);
   if (!execution_details) {
     execution_details = utils.getExecutionCLICommand(execution_id);
   }
-  var attachment_color = env.ST2_SLACK_SUCCESS_COLOR;
+  attachment_color = env.ST2_SLACK_SUCCESS_COLOR;
   if (data.message.indexOf("status : failed") > -1) {
     attachment_color = env.ST2_SLACK_FAIL_COLOR;
   }
@@ -40,14 +52,14 @@ SlackDataPostHandler.prototype.postData = function(data) {
   if (data.whisper != true) {
     text = util.format('%s :', data.user);
   }
-  robot.emit('slack-attachment', {
+  this.robot.emit('slack-attachment', {
     channel: recipient,
     text: text,
     content: {
       color: attachment_color,
       title: "Execution " + execution_id,
       title_link: execution_details,
-      text: formatter.formatData(data.message),
+      text: this.formatter.formatData(data.message),
       "mrkdwn_in": ["text", "pretext"]
     }
   });
@@ -74,10 +86,10 @@ DefaultFormatter.prototype.postData = function(data) {
   } else {
     recipient = data.channel;
   }
-  recipient = formatter.formatRecepient(recipient);
+  recipient = this.formatter.formatRecepient(recipient);
   args.unshift(recipient);
 
-  args.push(formatter.formatData(data.message));
+  args.push(this.formatter.formatData(data.message));
 
   execution_id = utils.getExecutionIdFromMessage(data.message);
   execution_details = utils.getExecutionHistoryUrl(execution_id);
@@ -89,7 +101,7 @@ DefaultFormatter.prototype.postData = function(data) {
     args.push(util.format('Execution details available at: %s', execution_details));
   }
 
-  robot.messageRoom.apply(robot, args);
+  this.robot.messageRoom.apply(robot, args);
 }
 
 var dataPostHandlers = {
@@ -97,11 +109,11 @@ var dataPostHandlers = {
   'default': DefaultFormatter
 };
 
-module.exports.getDataPostHandler = function(adapterName, robot) {
+module.exports.getDataPostHandler = function(adapterName, robot, formatter) {
   if (!(adapterName in dataPostHandlers)) {
     robot.logger.warning(
-      util.format('No supported formatter found for %s. Using DefaultFormatter.', adapterName));
+      util.format('No post handler found for %s. Using DefaultFormatter.', adapterName));
     adapterName = 'default';
   }
-  return new dataPostHandlers[adapterName](robot);
+  return new dataPostHandlers[adapterName](robot, formatter);
 };

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -49,7 +49,7 @@ SlackDataPostHandler.prototype.postData = function(data) {
   }
   var text = "";
   // PM user, notify user, or tell channel
-  if (data.whisper != true) {
+  if (!data.whisper) {
     text = util.format('%s :', data.user);
   }
   this.robot.emit('slack-attachment', {
@@ -63,7 +63,7 @@ SlackDataPostHandler.prototype.postData = function(data) {
       "mrkdwn_in": ["text", "pretext"]
     }
   });
-}
+};
 
 /*
   DefaultDataPostHandler.
@@ -73,6 +73,8 @@ function DefaultFormatter(robot) {
 }
 
 DefaultFormatter.prototype.postData = function(data) {
+  var args, recipient, execution_id, execution_details;
+
   args = [];
   // PM user, notify user, or tell channel
   if (data.user) {
@@ -101,8 +103,8 @@ DefaultFormatter.prototype.postData = function(data) {
     args.push(util.format('Execution details available at: %s', execution_details));
   }
 
-  this.robot.messageRoom.apply(robot, args);
-}
+  this.robot.messageRoom.apply(this.robot, args);
+};
 
 var dataPostHandlers = {
   'slack': SlackDataPostHandler,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "jshint": "^2.7.0",
     "jshint-stylish": "^2.0.0",
     "log": "1.4.0",
-    "nock": "^0.50.0"
+    "nock": "^0.50.0",
+    "sinon": "^1.17.1",
+    "sinon-chai": "^2.8.0"
   },
   "main": "index.js",
   "scripts": {

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -40,7 +40,7 @@ var _ = require('lodash'),
   slack_monkey_patch = require('../lib/slack_monkey_patch.js'),
   formatCommand = require('../lib/format_command.js'),
   formatData = require('../lib/format_data.js'),
-  postDatahandler = require('../lib/post_data.js'),
+  postData = require('../lib/post_data.js'),
   CommandFactory = require('../lib/command_factory.js'),
   authenticate = require('../lib/st2_authenticate.js');
 
@@ -97,8 +97,8 @@ module.exports = function(robot) {
   // formatter to manage per adapter message formatting.
   var formatter = formatData.getFormatter(robot.adapterName, robot);
 
-  // formatter to manage per adapter message formatting.
-  var postDataHandler = formatData.getFormatter(robot.adapterName, robot);
+  // handler to manage per adapter message post-ing.
+  var postDataHandler = postData.getDataPostHandler(robot.adapterName, robot, formatter);
 
   var loadCommands = function() {
     var request;
@@ -235,7 +235,7 @@ module.exports = function(robot) {
         data = req.body;
       }
 
-      postDatahandler.postData(data);
+      postDataHandler.postData(data);
 
       res.send('{"status": "completed", "msg": "Message posted successfully"}');
     } catch (e) {

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -40,6 +40,7 @@ var _ = require('lodash'),
   slack_monkey_patch = require('../lib/slack_monkey_patch.js'),
   formatCommand = require('../lib/format_command.js'),
   formatData = require('../lib/format_data.js'),
+  postDatahandler = require('../lib/post_data.js'),
   CommandFactory = require('../lib/command_factory.js'),
   authenticate = require('../lib/st2_authenticate.js');
 
@@ -95,6 +96,9 @@ module.exports = function(robot) {
 
   // formatter to manage per adapter message formatting.
   var formatter = formatData.getFormatter(robot.adapterName, robot);
+
+  // formatter to manage per adapter message formatting.
+  var postDataHandler = formatData.getFormatter(robot.adapterName, robot);
 
   var loadCommands = function() {
     var request;
@@ -231,57 +235,8 @@ module.exports = function(robot) {
         data = req.body;
       }
 
-      args = [];
-      // PM user, notify user, or tell channel
-      if (data.user) {
-        if (data.whisper === true) {
-          recipient = data.user;
-        } else {
-          recipient = data.channel;
-          // message = util.format('%s :\n%s', data.user, message);
-          args.push(util.format('%s :', data.user));
-        }
-      } else {
-        recipient = data.channel;
-      }
-      recipient = formatter.formatRecepient(recipient);
-      args.unshift(recipient);
+      postDatahandler.postData(data);
 
-      args.push(formatter.formatData(data.message));
-
-      execution_id = utils.getExecutionIdFromMessage(data.message);
-      execution_details = utils.getExecutionHistoryUrl(execution_id);
-      if (!execution_details) {
-        execution_details = utils.getExecutionCLICommand(execution_id);
-      }
-
-      if (execution_details) {
-        args.push(util.format('Execution details available at: %s', execution_details));
-      }
-
-      if (robot.adapterName == 'slack') {
-        var attachment_color = env.ST2_SLACK_SUCCESS_COLOR;
-        if (data.message.indexOf("status : failed") > -1) {
-          attachment_color = env.ST2_SLACK_FAIL_COLOR;
-        }
-        var text = "";
-        if (data.whisper != true) {
-          text = util.format('%s :', data.user);
-        }
-        robot.emit('slack-attachment', {
-          channel: recipient,
-          text: text,
-          content: {
-            color: attachment_color,
-            title: "Execution " + execution_id,
-            title_link: execution_details,
-            text: formatter.formatData(data.message),
-            "mrkdwn_in": ["text", "pretext"]
-          }
-        });
-      } else {
-        robot.messageRoom.apply(robot, args);
-      }
       res.send('{"status": "completed", "msg": "Message posted successfully"}');
     } catch (e) {
       robot.logger.error("Unable to decode JSON: " + e);

--- a/tests/test-formatdata.js
+++ b/tests/test-formatdata.js
@@ -34,7 +34,7 @@ describe('SlackFormatter', function() {
     var formatter = formatData.getFormatter(adapterName, null);
     var o = formatter.formatData('DATA', null);
     expect(o).to.be.an('string');
-    expect(o).to.equal('```\nDATA\n```');
+    expect(o).to.equal('DATA');
   });
 
   it('should truncate text more than a certain length', function() {
@@ -45,7 +45,7 @@ describe('SlackFormatter', function() {
     env.ST2_MAX_MESSAGE_LENGTH = org_max_length;
 
     expect(o).to.be.an('string');
-    expect(o).to.equal('```\nabcd efgh ...\n```');
+    expect(o).to.equal('abcd efgh ijklm');
 
   });
 

--- a/tests/test-postdata.js
+++ b/tests/test-postdata.js
@@ -1,0 +1,198 @@
+/*
+ Licensed to the StackStorm, Inc ('StackStorm') under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*jshint quotmark:false*/
+/*jshint -W030*/
+/*global describe, it, before, after*/
+"use strict";
+
+var chai = require("chai"),
+  env = process.env,
+  expect = chai.expect,
+  Robot = require('./dummy-robot.js'),
+  formatData = require('../lib/format_data.js'),
+  postData = require('../lib/post_data.js'),
+  sinon = require('sinon'),
+  sinonChai = require('sinon-chai'),
+  util = require('util');
+
+chai.use(sinonChai)
+
+describe("slack post data", function() {
+  var robot, formatter, postDataHandler;
+
+  robot = new Robot(false);
+  formatter = formatData.getFormatter('slack', robot);
+  postDataHandler = postData.getDataPostHandler('slack', robot, formatter);
+
+  env.ST2_SLACK_SUCCESS_COLOR = 'dfdfdf';
+  env.ST2_SLACK_FAIL_COLOR = 'danger';
+
+  it('should post success formatted slack-attachment', function() {
+    robot.emit = sinon.spy();
+    var input = {
+      user: 'stanley',
+      channel: '#stackstorm',
+      message: util.format('%s\nstatus : %s\nexecution: %s',
+                           'Short message',
+                           'succeeded',
+                           '1'),
+      whisper: false
+    };
+    postDataHandler.postData(input);
+    expect(robot.emit).to.have.been.calledOnce;
+    expect(robot.emit).to.have.been.calledWith(
+      'slack-attachment', {
+        channel: input.channel,
+        content: {
+          color: env.ST2_SLACK_SUCCESS_COLOR,
+          mrkdwn_in: ["text", "pretext"],
+          text: input.message,
+          title: "Execution 1",
+          title_link: "st2 execution get 1"
+        },
+        text: "stanley :"
+      }
+    );
+  });
+
+  it('should post fail formatted slack-attachment', function() {
+    robot.emit = sinon.spy();
+    var input = {
+      user: 'stanley',
+      channel: '#stackstorm',
+      message: util.format('%s\nstatus : %s\nexecution: %s',
+                           'Short message',
+                           'failed',
+                           '1'),
+      whisper: false
+    };
+    postDataHandler.postData(input);
+    expect(robot.emit).to.have.been.calledOnce;
+    expect(robot.emit).to.have.been.calledWith(
+      'slack-attachment', {
+        channel: input.channel,
+        content: {
+          color: env.ST2_SLACK_FAIL_COLOR,
+          mrkdwn_in: ["text", "pretext"],
+          text: input.message,
+          title: "Execution 1",
+          title_link: "st2 execution get 1"
+        },
+        text: "stanley :"
+      }
+    );
+  });
+
+  it('should whisper a slack-attachment', function() {
+    robot.emit = sinon.spy();
+    var input = {
+      user: 'stanley',
+      channel: '#stackstorm',
+      message: util.format('%s\nstatus : %s\nexecution: %s',
+                           'Short message',
+                           'succeeded',
+                           '1'),
+      whisper: true
+    };
+    postDataHandler.postData(input);
+    expect(robot.emit).to.have.been.calledOnce;
+    expect(robot.emit).to.have.been.calledWith(
+      'slack-attachment', {
+        channel: input.user,
+        content: {
+          color: env.ST2_SLACK_SUCCESS_COLOR,
+          mrkdwn_in: ["text", "pretext"],
+          text: input.message,
+          title: "Execution 1",
+          title_link: "st2 execution get 1"
+        },
+        text: ""
+      }
+    );
+  });
+
+});
+
+describe("default post data", function() {
+  var robot, formatter, postDataHandler;
+
+  robot = new Robot(false);
+  formatter = formatData.getFormatter('default', robot);
+  postDataHandler = postData.getDataPostHandler('default', robot, formatter);
+
+  it('should send proper args to robot.messageRoom', function() {
+    robot.messageRoom = sinon.spy();
+    var input = {
+      user: 'stanley',
+      channel: '#stackstorm',
+      message: util.format('%s\nstatus : %s\nexecution: %s',
+                           'Short message',
+                           'succeeded',
+                           '1'),
+      whisper: false
+    };
+    postDataHandler.postData(input);
+    expect(robot.messageRoom).to.have.been.calledOnce;
+    expect(robot.messageRoom).to.have.been.calledWith(
+      '#stackstorm',
+      'stanley :',
+      input.message,
+      util.format('Execution details available at: st2 execution get %s', '1')
+    );
+  });
+
+  it('should whisper to robot.messageRoom', function() {
+    robot.messageRoom = sinon.spy();
+    var input = {
+      user: 'stanley',
+      channel: '#stackstorm',
+      message: util.format('%s\nstatus : %s\nexecution: %s',
+                           'Short message',
+                           'succeeded',
+                           '1'),
+      whisper: true
+    };
+    postDataHandler.postData(input);
+    expect(robot.messageRoom).to.have.been.calledOnce;
+    expect(robot.messageRoom).to.have.been.calledWith(
+      'stanley',
+      input.message,
+      util.format('Execution details available at: st2 execution get %s', '1')
+    );
+  });
+
+  it('should send to channel via robot.messageRoom', function() {
+    robot.messageRoom = sinon.spy();
+    var input = {
+      channel: '#stackstorm',
+      message: util.format('%s\nstatus : %s\nexecution: %s',
+                           'Short message',
+                           'succeeded',
+                           '1'),
+      whisper: true
+    };
+    postDataHandler.postData(input);
+    expect(robot.messageRoom).to.have.been.calledOnce;
+    expect(robot.messageRoom).to.have.been.calledWith(
+      '#stackstorm',
+      input.message,
+      util.format('Execution details available at: st2 execution get %s', '1')
+    );
+  });
+
+});


### PR DESCRIPTION
* Also tests now since it can be unit tested
* Truncation of messages posted to slack is no longer necessary.

Validated changes with `slack` and `hipchat`. Looks like all the basic stuff is still working fine after my change.