### PR TITLE
More relaxed command matching in Hubot

### DIFF
--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -48,7 +48,7 @@ CommandFactory.prototype.getRegexForFormatString = function(format) {
   // be skipped.
   regex_str = format.replace(/\s+{{\s*\S+\s*=.+?}}/g, '(\\s+([\\s\\S]+?))?');
   regex_str = regex_str.replace(/{{.+?}}/g, '([\\s\\S]+?)');
-  regex = new RegExp(regex_str + '(\\s+(\\S+)=([\\s\\S]+?))*' + '$');
+  regex = new RegExp(regex_str + '(\\s+(\\S+)\s*=\s*([\\s\\S]+?))*' + '$');
   return regex;
 };
 

--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -49,7 +49,6 @@ CommandFactory.prototype.getRegexForFormatString = function(format) {
   regex_str = format.replace(/\s+{{\s*\S+\s*=.+?}}/g, '\\s+([\\s\\S]*?)');
   regex_str = regex_str.replace(/{{.+?}}/g, '([\\s\\S]+?)');
   regex = new RegExp(regex_str + '(\\s+(\\S+)=([\\s\\S]+?))*' + '$');
-  console.log(regex);
   return regex;
 };
 

--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -46,7 +46,7 @@ CommandFactory.prototype.getRegexForFormatString = function(format) {
   // number of key=value pairs at the end of the string
   // Format parameters with default value {{param=value}} are allowed to
   // be skipped.
-  regex_str = format.replace(/\s+{{\s*\S+\s*=.+?}}/g, '\\s+([\\s\\S]*?)');
+  regex_str = format.replace(/\s+{{\s*\S+\s*=.+?}}/g, '(\\s+([\\s\\S]+?))?');
   regex_str = regex_str.replace(/{{.+?}}/g, '([\\s\\S]+?)');
   regex = new RegExp(regex_str + '(\\s+(\\S+)=([\\s\\S]+?))*' + '$');
   return regex;

--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -42,10 +42,12 @@ function CommandFactory(robot) {
 CommandFactory.prototype.getRegexForFormatString = function(format) {
   var regex_str, regex;
 
-  // Note: We replace format parameters with (.+?) and allow arbitrary
+  // Note: We replace format parameters with ([\s\S]+?) and allow arbitrary
   // number of key=value pairs at the end of the string
   // Format parameters with default value {{param=value}} are allowed to
   // be skipped.
+  // Note that we use "[\s\S]" instead of "." to allow multi-line values
+  // and multi-line commands in general.
   regex_str = format.replace(/\s+{{\s*\S+\s*=.+?}}/g, '(\\s+([\\s\\S]+?))?');
   regex_str = regex_str.replace(/{{.+?}}/g, '([\\s\\S]+?)');
   regex = new RegExp(regex_str + '(\\s+(\\S+)\s*=\s*([\\s\\S]+?))*' + '$');

--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -46,10 +46,10 @@ CommandFactory.prototype.getRegexForFormatString = function(format) {
   // number of key=value pairs at the end of the string
   // Format parameters with default value {{param=value}} are allowed to
   // be skipped.
-  regex_str = format.replace(/\s+{{\w+\s*=.+?}}/g, '(\\s+)?([^\\s]*?)');
-  regex_str = regex_str.replace(/{{.+?}}/g, '([\\S\\s]+?)');
-  regex = new RegExp(regex_str + '(\\s+)?(\\s?(\\w+)=(\\w+)){0,}' + '$');
-
+  regex_str = format.replace(/\s+{{\s*\S+\s*=.+?}}/g, '\\s+([\\s\\S]*?)');
+  regex_str = regex_str.replace(/{{.+?}}/g, '([\\s\\S]+?)');
+  regex = new RegExp(regex_str + '(\\s+(\\S+)=([\\s\\S]+?))*' + '$');
+  console.log(regex);
   return regex;
 };
 

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -203,7 +203,7 @@ module.exports = function(robot) {
     );
   };
 
-  robot.respond(/(.+?)$/i, function(msg) {
+  robot.respond(/([\s\S]+?)$/i, function(msg) {
     var command, result, command_name, format_string;
 
     // Normalize the command and remove special handling provided by the chat service.


### PR DESCRIPTION
1. `\S` instead of `\w` to work with keys with `-` in them (closes #52).
2. `[\s\S]` instead of `.` to work with multiline matches.
3. More relaxed with whitespace inside brackets and around the equal sign for default params.