### PR TITLE
Adding support for new ChatOps parameters

### DIFF
--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -42,17 +42,19 @@ function CommandFactory(robot) {
 CommandFactory.prototype.getRegexForFormatString = function(format) {
   var regex_str, regex;
 
-  // Note: We replace format parameters with (.+?) and allow arbitrary
+  // Note: We replace format parameters with ([\s\S]+?) and allow arbitrary
   // number of key=value pairs at the end of the string
   // Format parameters with default value {{param=value}} are allowed to
   // be skipped.
+  // Note that we use "[\s\S]" instead of "." to allow multi-line values
+  // and multi-line commands in general.
   regex_str = format.replace(/\s+{{\s*\S+\s*=.+?}}/g, '(\\s+([\\s\\S]+?))?');
   regex_str = regex_str.replace(/{{.+?}}/g, '([\\s\\S]+?)');
   regex = new RegExp(regex_str + '(\\s+(\\S+)\s*=\s*([\\s\\S]+?))*' + '$');
   return regex;
 };
 
-CommandFactory.prototype.addCommand = function(command, name, format, action_alias) {
+CommandFactory.prototype.addCommand = function(command, name, format, action_alias, hidden) {
   var compiled_template, context, command_string, regex;
 
   if (!format) {
@@ -68,7 +70,9 @@ CommandFactory.prototype.addCommand = function(command, name, format, action_ali
   compiled_template = _.template('${robotName} ${command}');
   command_string = compiled_template(context);
 
-  this.robot.commands.push(command_string);
+  if (!hidden) {
+    this.robot.commands.push(command_string);
+  }
 
   regex = this.getRegexForFormatString(format);
   this.st2_hubot_commands.push(command_string);

--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -102,7 +102,8 @@ CommandFactory.prototype.removeCommands = function() {
 };
 
 CommandFactory.prototype.getMatchingCommand = function(command) {
-  var result, common_prefix, command_name, command_arguments, format_strings, i, format_string, regex;
+  var result, common_prefix, command_name, command_arguments, format_strings, 
+      i, format_string, regex, action_alias;
 
   // 1. Try to use regex search - this works for commands with a format string
   format_strings = Object.keys(this.st2_commands_regex_map);
@@ -111,8 +112,10 @@ CommandFactory.prototype.getMatchingCommand = function(command) {
     format_string = format_strings[i];
     regex = this.st2_commands_regex_map[format_string];
     if (regex.test(command)) {
-      command_name = this.st2_commands_format_map[format_string].name;
-      return [command_name, format_string];
+      action_alias = this.st2_commands_format_map[format_string]
+      command_name = action_alias.name;
+      
+      return [command_name, format_string, action_alias];
     }
   }
 

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -139,15 +139,16 @@ module.exports = function(robot) {
         command_factory.removeCommands();
 
         _.each(parsed_body, function(action_alias) {
-          var name, formats, description, i, format, command;
+          var name, formats, description, i, format, command, aliases;
 
           if (!action_alias) {
             robot.logger.error('No action alias specified for command: ' + name);
             return;
           }
-
+          
           name = action_alias.name;
           formats = action_alias.formats;
+          aliases = action_alias.aliases;
           description = action_alias.description;
 
           if (!formats || formats.length === 0) {
@@ -161,6 +162,16 @@ module.exports = function(robot) {
 
             command_factory.addCommand(command, name, format, action_alias);
           }
+
+          if (aliases && aliases.length > 0) {
+            for (i = 0; i < aliases.length; i++) {
+              format = aliases[i];
+              command = formatCommand(robot.logger, name, format, description);
+
+              command_factory.addCommand(command, name, format, action_alias, true);
+            }
+	  }
+ 
         });
       }
     );

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -139,7 +139,7 @@ module.exports = function(robot) {
         command_factory.removeCommands();
 
         _.each(parsed_body, function(action_alias) {
-          var name, formats, description, i, format, command, aliases;
+          var name, formats, description, i, ii, format, command;
 
           if (!action_alias) {
             robot.logger.error('No action alias specified for command: ' + name);
@@ -148,7 +148,6 @@ module.exports = function(robot) {
           
           name = action_alias.name;
           formats = action_alias.formats;
-          aliases = action_alias.aliases;
           description = action_alias.description;
 
           if (!formats || formats.length === 0) {
@@ -158,20 +157,19 @@ module.exports = function(robot) {
 
           for (i = 0; i < formats.length; i++) {
             format = formats[i];
-            command = formatCommand(robot.logger, name, format, description);
-
-            command_factory.addCommand(command, name, format, action_alias);
+            if (typeof(format) === "string") {
+              command = formatCommand(robot.logger, name, format, description);
+              command_factory.addCommand(command, name, format, action_alias);
+            } else {
+              command = formatCommand(robot.logger, name, format.display, description);
+              command_factory.addCommand(command, name, format.display, action_alias);
+              for (ii = 0; ii < format.representation.length; ii++) {
+                command = formatCommand(robot.logger, name, format.representation[ii], description);
+                command_factory.addCommand(command, name, format.representation[ii], action_alias, true);
+              }
+            }
           }
 
-          if (aliases && aliases.length > 0) {
-            for (i = 0; i < aliases.length; i++) {
-              format = aliases[i];
-              command = formatCommand(robot.logger, name, format, description);
-
-              command_factory.addCommand(command, name, format, action_alias, true);
-            }
-	  }
- 
         });
       }
     );


### PR DESCRIPTION
1. `aliases` don't get registered in Hubot's help.
2. `ack` configures the acknowledgement message: formatting and enabling/disabling.
3. `result` configures the result message: formatting and enabling/disabling.
4. The new regex from `chatops/regex` is also merged here.