### PR TITLE
Revert ignoring of empty messages

### DIFF
--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -271,9 +271,7 @@ module.exports = function(robot) {
         data = req.body;
       }
 
-      if (data && data.message) {
-        postDataHandler.postData(data);
-      }
+      postDataHandler.postData(data);
 
       res.send('{"status": "completed", "msg": "Message posted successfully"}');
     } catch (e) {
@@ -304,9 +302,8 @@ module.exports = function(robot) {
           data = e.data;
         }
 
-        if (data && data.message) {
-          postDataHandler.postData(data);
-        }
+        postDataHandler.postData(data);
+
       });
     });
 


### PR DESCRIPTION
Moved disabling of the result output to the back-end, because `hubot-stackstorm` shouldn’t be concerned with this.