### PR TITLE
Exclude help entries from regex map

### DIFF
--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -18,6 +18,8 @@ limitations under the License.
 "use strict";
 
 var _ = require('lodash');
+var utils = require('./utils.js');
+
 
 /**
  * Manage command for stackstorm, storing them in robot and providing
@@ -55,7 +57,7 @@ CommandFactory.prototype.getRegexForFormatString = function(format) {
   return regex;
 };
 
-CommandFactory.prototype.addCommand = function(command, name, format, action_alias, hidden) {
+CommandFactory.prototype.addCommand = function(command, name, format, action_alias, flag) {
   var compiled_template, context, command_string, regex;
 
   if (!format) {
@@ -71,15 +73,16 @@ CommandFactory.prototype.addCommand = function(command, name, format, action_ali
   compiled_template = _.template('${robotName} ${command}');
   command_string = compiled_template(context);
 
-  if (!hidden) {
-    this.robot.commands.push(command_string);
-  }
-
   regex = this.getRegexForFormatString(format);
   this.st2_hubot_commands.push(command_string);
   this.st2_commands_name_map[name] = action_alias;
   this.st2_commands_format_map[format] = action_alias;
-  this.st2_commands_regex_map[format] = regex;
+  if (!flag || flag === utils.DISPLAY) {
+    this.robot.commands.push(command_string);
+  }
+  if (!flag || flag === utils.REPRESENTATION) {
+    this.st2_commands_regex_map[format] = regex;
+  }
 
   this.robot.logger.debug('Added command: ' + command);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,6 +25,8 @@ var WEBUI_EXECUTION_HISTORY_URL = '%s/#/history/%s/general';
 var MESSAGE_EXECUTION_ID_REGEX = new RegExp('.*execution: (.+).*');
 var CLI_EXECUTION_GET_CMD = 'st2 execution get %s';
 var PRETEXT_DELIMITER = '::';
+var DISPLAY = 1;
+var REPRESENTATION = 2;
 
 
 function isNull(value) {
@@ -85,3 +87,5 @@ exports.isNull = isNull;
 exports.getExecutionHistoryUrl = getExecutionHistoryUrl;
 exports.parseUrl = parseUrl;
 exports.splitMessage = splitMessage;
+exports.DISPLAY = DISPLAY;
+exports.REPRESENTATION = REPRESENTATION;

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -179,11 +179,13 @@ module.exports = function(robot) {
 
           _.each(formats, function (format) {
             var command = formatCommand(robot.logger, name, format.display || format, description);
-            command_factory.addCommand(command, name, format.display || format, alias);
+            command_factory.addCommand(command, name, format.display || format, alias,
+                                       format.display ? utils.DISPLAY : false);
 
             _.each(format.representation, function (representation) {
               command = formatCommand(robot.logger, name, representation, description);
-              command_factory.addCommand(command, name, representation, alias, true);
+              command_factory.addCommand(command, name, representation, alias,
+                                         utils.REPRESENTATION);
             });
           });
         });


### PR DESCRIPTION
Overlooked this one: when a format string is specified as a “display+representation” object, display is help-exclusive so it shouldn’t be matched as a command.