### PR TITLE
Better multiline support

### DIFF
--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -52,7 +52,7 @@ CommandFactory.prototype.getRegexForFormatString = function(format) {
   // and multi-line commands in general.
   extra_params = '(\\s+(\\S+)\\s*=("([\\s\\S]*?)"|\'([\\s\\S]*?)\'|({[\\s\\S]*?})|(\\S+))\\s*)*$';
   regex_str = format.replace(/(\s*){{\s*\S+\s*=\s*(?:({.+?}|.+?))\s*}}(\s*)/g, '\\s*($1([\\s\\S]+?)$3)?\\s*');
-  regex_str = regex_str.replace(/{{.+?}}/g, '([\\s\\S]+?)');
+  regex_str = regex_str.replace(/\s*{{.+?}}\s*/g, '\\s*([\\s\\S]+?)\\s*');
   regex = new RegExp(regex_str + extra_params);
   return regex;
 };


### PR DESCRIPTION
Converting spaces before and after arguments to `\s` for better multiline support.