### PR TITLE
A less common separator

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,7 +24,7 @@ var _ = require('lodash');
 var WEBUI_EXECUTION_HISTORY_URL = '%s/#/history/%s/general';
 var MESSAGE_EXECUTION_ID_REGEX = new RegExp('.*execution: (.+).*');
 var CLI_EXECUTION_GET_CMD = 'st2 execution get %s';
-var PRETEXT_DELIMITER = '::';
+var PRETEXT_DELIMITER = '{~}';
 var DISPLAY = 1;
 var REPRESENTATION = 2;
 


### PR DESCRIPTION
`::` is too widely used—including config files—and could behave badly when outputting gists.