### PR TITLE
Tweak help generation

### DIFF
--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -70,7 +70,7 @@ CommandFactory.prototype.addCommand = function(command, name, format, action_ali
     command: command
   };
 
-  compiled_template = _.template('${robotName} ${command}');
+  compiled_template = _.template('hubot ${command}');
   command_string = compiled_template(context);
 
   regex = this.getRegexForFormatString(format);


### PR DESCRIPTION
Due to how hubot-help is implemented, it automatically replaces every mention of 'hubot' with bot alias.

I personally think this was a bad idea on hubot's part and it seems especially awful in our case, but we've decided to follow this convention for the time being instead of re-implementing help module.