### PR TITLE
Hipchat postdata

### DIFF
--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -94,7 +94,7 @@ HipchatDataPostHandler.prototype.postData = function(data) {
     if (data.source_channel) {
       this.robot.messageRoom.call(this.robot, recipient, split_message.pretext);
     } else {
-      this.robot.send.call(this.robot, data.reply_to, split_message.pretext);
+      this.robot.send.call(this.robot, {user: data.reply_to, message: split_message.pretext});
     }
 
   }
@@ -102,7 +102,7 @@ HipchatDataPostHandler.prototype.postData = function(data) {
     if (data.source_channel) {
       this.robot.messageRoom.call(this.robot, recipient, this.formatter.formatData(split_message.text));
     } else {
-      this.robot.send.call(this.robot, data.reply_to, this.formatter.formatData(split_message.text));
+      this.robot.send.call(this.robot, {user: data.reply_to, message: this.formatter.formatData(split_message.text)});
     }
   }
 };

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -72,7 +72,7 @@ function HipchatDataPostHandler(robot, formatter) {
 
 HipchatDataPostHandler.prototype.postData = function(data) {
   var recipient, split_message, formatted_message,
-      text = "";
+      pretext = "";
 
   if (data.whisper && data.user) {
     recipient = data.user;
@@ -84,12 +84,15 @@ HipchatDataPostHandler.prototype.postData = function(data) {
   recipient = this.formatter.formatRecepient(recipient);
 
   split_message = utils.splitMessage(this.formatter.formatData(data.message));
+  if (pretext) {
+    split_message.pretext = pretext + "\n" + split_message.pretext
+  }
 
   if (split_message.pretext && split_message.text) {
     /* Hipchat is unable to render text and code in the
        same message */
-    var actual_pretext = pretext + "\n" + split_message.pretext
-    this.robot.messageRoom.call(this.robot, recipient, actual_pretext);
+
+    this.robot.messageRoom.call(this.robot, recipient, split_message.pretext);
     this.robot.messageRoom.call(this.robot, recipient, split_message.text);
   } else {
     formatted_message = split_message.pretext || split_message.text;

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -84,15 +84,17 @@ HipchatDataPostHandler.prototype.postData = function(data) {
   recipient = this.formatter.formatRecepient(recipient);
   text += this.formatter.formatData(data.message);
 
-  // Ignore the delimiter in the default formatter and just concat parts.
-  split_message = utils.splitMessage(text);
+  split_message = utils.splitMessage(this.formatter.formatData(data.message));
+
   if (split_message.pretext && split_message.text) {
-    formatted_message = util.format("%s\n%s", split_message.pretext, split_message.text);
+    /* Hipchat is unable to render text and code in the
+       same message */
+    this.robot.messageRoom.call(this.robot, recipient, split_message.pretext);
+    this.robot.messageRoom.call(this.robot, recipient, split_message.text);
   } else {
     formatted_message = split_message.pretext || split_message.text;
+    this.robot.messageRoom.call(this.robot, recipient, formatted_message);
   }
-
-  this.robot.messageRoom.call(this.robot, recipient, formatted_message);
 };
 
 /*
@@ -130,7 +132,7 @@ DefaultFormatter.prototype.postData = function(data) {
 
 var dataPostHandlers = {
   'slack': SlackDataPostHandler,
-  'hipchat': DefaultFormatter,
+  'hipchat': HipchatDataPostHandler,
   'default': DefaultFormatter
 };
 

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -74,13 +74,14 @@ HipchatDataPostHandler.prototype.postData = function(data) {
   var recipient, split_message, formatted_message,
       pretext = "";
 
+  recipient = data.channel;
   if (data.user && !data.whisper) {
-    recipient = data.channel;
     pretext = (data.user && !data.whisper) ? util.format('@%s: ', data.user) : "";
   }
 
-  recipient = this.formatter.formatRecepient(recipient);
-
+  if (recipient.indexOf('@') === -1 ) {
+    recipient = this.formatter.formatRecepient(recipient);
+  }
   split_message = utils.splitMessage(data.message);
   if (pretext) {
     split_message.pretext = pretext + split_message.pretext
@@ -92,14 +93,14 @@ HipchatDataPostHandler.prototype.postData = function(data) {
     if (data.whisper) {
       this.robot.messageRoom.call(this.robot, recipient, split_message.pretext);
     } else {
-      this.robot.send.call(this.robot, {user: data.userjid, message: split_message.pretext});
+      this.robot.send.call(this.robot, {user: data.channel, message: split_message.pretext});
     }
   }
   if (split_message.text) {
     if (data.whisper) {
       this.robot.messageRoom.call(this.robot, recipient, this.formatter.formatData(split_message.text));
     } else {
-      this.robot.send.call(this.robot, {user: data.userjid, message: this.formatter.formatData(split_message.text)});
+      this.robot.send.call(this.robot, {user: data.channel, message: this.formatter.formatData(split_message.text)});
     }
   }
 };

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -74,9 +74,7 @@ HipchatDataPostHandler.prototype.postData = function(data) {
   var recipient, split_message, formatted_message,
       pretext = "";
 
-  if (data.whisper && data.user) {
-    recipient = data.user;
-  } else {
+  if (data.user && !data.whisper) {
     recipient = data.channel;
     pretext = (data.user && !data.whisper) ? util.format('@%s: ', data.user) : "";
   }
@@ -91,18 +89,17 @@ HipchatDataPostHandler.prototype.postData = function(data) {
   /*  Hipchat is unable to render text and code in the
       same message, so split them */
   if (split_message.pretext) {
-    if (data.source_channel) {
+    if (data.whisper) {
       this.robot.messageRoom.call(this.robot, recipient, split_message.pretext);
     } else {
-      this.robot.send.call(this.robot, {user: data.reply_to, message: split_message.pretext});
+      this.robot.send.call(this.robot, {user: data.userjid, message: split_message.pretext});
     }
-
   }
   if (split_message.text) {
-    if (data.source_channel) {
+    if (data.whisper) {
       this.robot.messageRoom.call(this.robot, recipient, this.formatter.formatData(split_message.text));
     } else {
-      this.robot.send.call(this.robot, {user: data.reply_to, message: this.formatter.formatData(split_message.text)});
+      this.robot.send.call(this.robot, {user: data.userjid, message: this.formatter.formatData(split_message.text)});
     }
   }
 };

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -91,10 +91,19 @@ HipchatDataPostHandler.prototype.postData = function(data) {
   /*  Hipchat is unable to render text and code in the
       same message, so split them */
   if (split_message.pretext) {
-    this.robot.messageRoom.call(this.robot, recipient, split_message.pretext);
+    if (data.source_channel) {
+      this.robot.messageRoom.call(this.robot, recipient, split_message.pretext);
+    } else {
+      this.robot.send.call(this.robot, data.reply_to, split_message.pretext);
+    }
+
   }
   if (split_message.text) {
-    this.robot.messageRoom.call(this.robot, recipient, this.formatter.formatData(split_message.text));
+    if (data.source_channel) {
+      this.robot.messageRoom.call(this.robot, recipient, this.formatter.formatData(split_message.text));
+    } else {
+      this.robot.send.call(this.robot, data.reply_to, this.formatter.formatData(split_message.text));
+    }
   }
 };
 

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -91,14 +91,14 @@ HipchatDataPostHandler.prototype.postData = function(data) {
       same message, so split them */
   if (split_message.pretext) {
     if (data.whisper) {
-      this.robot.send.call(this.robot, user: data.channel, split_message.pretext);
+      this.robot.send.call(this.robot, data.channel, split_message.pretext);
     } else {
       this.robot.messageRoom.call(this.robot, recipient, split_message.pretext);
     }
   }
   if (split_message.text) {
     if (data.whisper) {
-      this.robot.send.call(this.robot, user: data.channel, this.formatter.formatData(split_message.text));
+      this.robot.send.call(this.robot, data.channel, this.formatter.formatData(split_message.text));
     } else {
       this.robot.messageRoom.call(this.robot, recipient, this.formatter.formatData(split_message.text));
     }

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -91,19 +91,15 @@ HipchatDataPostHandler.prototype.postData = function(data) {
       same message, so split them */
   if (split_message.pretext) {
     if (data.whisper) {
-      this.robot.logger.call(this.robot, "sending pretext message to user")
-      this.robot.send.call(this.robot, {user: data.channel, message: split_message.pretext});
+      this.robot.send.call(this.robot, {user: data.channel, split_message.pretext});
     } else {
-      this.robot.logger.call(this.robot, "sending pretext message to room")
       this.robot.messageRoom.call(this.robot, recipient, split_message.pretext);
     }
   }
   if (split_message.text) {
     if (data.whisper) {
-      this.robot.logger.call(this.robot, "sending text message to user")
-      this.robot.send.call(this.robot, {user: data.channel, message: this.formatter.formatData(split_message.text)});
+      this.robot.send.call(this.robot, user: data.channel, this.formatter.formatData(split_message.text));
     } else {
-      this.robot.logger.call(this.robot, "sending text message to room")
       this.robot.messageRoom.call(this.robot, recipient, this.formatter.formatData(split_message.text));
     }
   }

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -63,6 +63,39 @@ SlackDataPostHandler.prototype.postData = function(data) {
 };
 
 /*
+  HipchatDataPostHandler.
+*/
+function HipchatDataPostHandler(robot, formatter) {
+  this.robot = robot;
+  this.formatter = formatter;
+}
+
+HipchatDataPostHandler.prototype.postData = function(data) {
+  var recipient, split_message, formatted_message,
+      text = "";
+
+  if (data.whisper && data.user) {
+    recipient = data.user;
+  } else {
+    recipient = data.channel;
+    text = (data.user && !data.whisper) ? util.format('%s: ', data.user) : "";
+  }
+
+  recipient = this.formatter.formatRecepient(recipient);
+  text += this.formatter.formatData(data.message);
+
+  // Ignore the delimiter in the default formatter and just concat parts.
+  split_message = utils.splitMessage(text);
+  if (split_message.pretext && split_message.text) {
+    formatted_message = util.format("%s\n%s", split_message.pretext, split_message.text);
+  } else {
+    formatted_message = split_message.pretext || split_message.text;
+  }
+
+  this.robot.messageRoom.call(this.robot, recipient, formatted_message);
+};
+
+/*
   DefaultDataPostHandler.
 */
 function DefaultFormatter(robot, formatter) {

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -97,6 +97,7 @@ DefaultFormatter.prototype.postData = function(data) {
 
 var dataPostHandlers = {
   'slack': SlackDataPostHandler,
+  'hipchat': DefaultFormatter,
   'default': DefaultFormatter
 };
 

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -91,16 +91,16 @@ HipchatDataPostHandler.prototype.postData = function(data) {
       same message, so split them */
   if (split_message.pretext) {
     if (data.whisper) {
-      this.robot.messageRoom.call(this.robot, recipient, split_message.pretext);
-    } else {
       this.robot.send.call(this.robot, {user: data.channel, message: split_message.pretext});
+    } else {
+      this.robot.messageRoom.call(this.robot, recipient, split_message.pretext);
     }
   }
   if (split_message.text) {
     if (data.whisper) {
-      this.robot.messageRoom.call(this.robot, recipient, this.formatter.formatData(split_message.text));
-    } else {
       this.robot.send.call(this.robot, {user: data.channel, message: this.formatter.formatData(split_message.text)});
+    } else {
+      this.robot.messageRoom.call(this.robot, recipient, this.formatter.formatData(split_message.text));
     }
   }
 };

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -91,7 +91,7 @@ HipchatDataPostHandler.prototype.postData = function(data) {
       same message, so split them */
   if (split_message.pretext) {
     if (data.whisper) {
-      this.robot.send.call(this.robot, {user: data.channel, split_message.pretext});
+      this.robot.send.call(this.robot, user: data.channel, split_message.pretext);
     } else {
       this.robot.messageRoom.call(this.robot, recipient, split_message.pretext);
     }

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -83,20 +83,18 @@ HipchatDataPostHandler.prototype.postData = function(data) {
 
   recipient = this.formatter.formatRecepient(recipient);
 
-  split_message = utils.splitMessage(this.formatter.formatData(data.message));
+  split_message = utils.splitMessage(data.message);
   if (pretext) {
-    split_message.pretext = pretext + "\n" + split_message.pretext
+    split_message.pretext = pretext + split_message.pretext
   }
 
-  if (split_message.pretext && split_message.text) {
-    /* Hipchat is unable to render text and code in the
-       same message */
-
+  /*  Hipchat is unable to render text and code in the
+      same message, so split them */
+  if (split_message.pretext) {
     this.robot.messageRoom.call(this.robot, recipient, split_message.pretext);
-    this.robot.messageRoom.call(this.robot, recipient, split_message.text);
-  } else {
-    formatted_message = split_message.pretext || split_message.text;
-    this.robot.messageRoom.call(this.robot, recipient, formatted_message);
+  }
+  if (split_message.text) {
+    this.robot.messageRoom.call(this.robot, recipient, this.formatter.formatData(split_message.text));
   }
 };
 

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -142,5 +142,7 @@ module.exports.getDataPostHandler = function(adapterName, robot, formatter) {
       util.format('No post handler found for %s. Using DefaultFormatter.', adapterName));
     adapterName = 'default';
   }
+  robot.logger.debug(
+    util.format('Using %s post data handler.', adapterName));
   return new dataPostHandlers[adapterName](robot, formatter);
 };

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -78,18 +78,18 @@ HipchatDataPostHandler.prototype.postData = function(data) {
     recipient = data.user;
   } else {
     recipient = data.channel;
-    text = (data.user && !data.whisper) ? util.format('%s: ', data.user) : "";
+    pretext = (data.user && !data.whisper) ? util.format('@%s: ', data.user) : "";
   }
 
   recipient = this.formatter.formatRecepient(recipient);
-  text += this.formatter.formatData(data.message);
 
   split_message = utils.splitMessage(this.formatter.formatData(data.message));
 
   if (split_message.pretext && split_message.text) {
     /* Hipchat is unable to render text and code in the
        same message */
-    this.robot.messageRoom.call(this.robot, recipient, split_message.pretext);
+    var actual_pretext = pretext + "\n" + split_message.pretext
+    this.robot.messageRoom.call(this.robot, recipient, actual_pretext);
     this.robot.messageRoom.call(this.robot, recipient, split_message.text);
   } else {
     formatted_message = split_message.pretext || split_message.text;

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -76,7 +76,7 @@ HipchatDataPostHandler.prototype.postData = function(data) {
 
   recipient = data.channel;
   if (data.user && !data.whisper) {
-    pretext = (data.user && !data.whisper) ? util.format('@%s: ', data.user) : "";
+    pretext = util.format('@%s: ', data.user);
   }
 
   if (recipient.indexOf('@') === -1 ) {
@@ -84,22 +84,26 @@ HipchatDataPostHandler.prototype.postData = function(data) {
   }
   split_message = utils.splitMessage(data.message);
   if (pretext) {
-    split_message.pretext = pretext + split_message.pretext
+    split_message.pretext = pretext + split_message.pretext;
   }
 
   /*  Hipchat is unable to render text and code in the
       same message, so split them */
   if (split_message.pretext) {
     if (data.whisper) {
+      this.robot.logger.call(this.robot, "sending pretext message to user")
       this.robot.send.call(this.robot, {user: data.channel, message: split_message.pretext});
     } else {
+      this.robot.logger.call(this.robot, "sending pretext message to room")
       this.robot.messageRoom.call(this.robot, recipient, split_message.pretext);
     }
   }
   if (split_message.text) {
     if (data.whisper) {
+      this.robot.logger.call(this.robot, "sending text message to user")
       this.robot.send.call(this.robot, {user: data.channel, message: this.formatter.formatData(split_message.text)});
     } else {
+      this.robot.logger.call(this.robot, "sending text message to room")
       this.robot.messageRoom.call(this.robot, recipient, this.formatter.formatData(split_message.text));
     }
   }

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -217,7 +217,7 @@ module.exports = function(robot) {
       'format': format_string,
       'command': command,
       'user': name,
-      'source_channel': msg.message.room,
+      'source_channel': msg.message.room || msg.message.user.reply_to,
       'notification_route': env.ST2_ROUTE || 'hubot'
     };
     var sendAck = function (res) {

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -213,9 +213,7 @@ module.exports = function(robot) {
       name = msg.message.user.mention_name;
     };
     var room = msg.message.room;
-    var whisper = false;
     if (room == undefined) {
-      whisper = true;
       room = msg.message.user.jid;
     }
     var payload = {
@@ -223,7 +221,6 @@ module.exports = function(robot) {
       'format': format_string,
       'command': command,
       'user': name,
-      'whisper': whisper,
       'source_channel': room,
       'notification_route': env.ST2_ROUTE || 'hubot'
     };
@@ -296,6 +293,11 @@ module.exports = function(robot) {
       } else {
         data = req.body;
       }
+      // Special handler to try and figure out when a hipchat message
+      // is a whisper:
+      if (robot.adapterName == 'hipchat' && !data.whisper && data.channel.indexOf('@') > -1 ) {
+        data.whisper = true;
+      }
 
       postDataHandler.postData(data);
 
@@ -326,6 +328,12 @@ module.exports = function(robot) {
           data = JSON.parse(e.data).payload;
         } else {
           data = e.data;
+        }
+
+        // Special handler to try and figure out when a hipchat message
+        // is a whisper:
+        if (robot.adapterName == 'hipchat' && !data.whisper && data.channel.indexOf('@') > -1 ) {
+          data.whisper = true;
         }
 
         postDataHandler.postData(data);

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -217,7 +217,7 @@ module.exports = function(robot) {
       'format': format_string,
       'command': command,
       'user': name,
-      'source_channel': msg.message.room || msg.message.reply_to,
+      'source_channel': msg.message.room || msg.message.user.jid,
       'notification_route': env.ST2_ROUTE || 'hubot'
     };
     var sendAck = function (res) {

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -217,8 +217,7 @@ module.exports = function(robot) {
       'format': format_string,
       'command': command,
       'user': name,
-      'source_channel': msg.message.room,
-      'reply_to': msg.message.reply_to,
+      'source_channel': msg.message.room || msg.message.reply_to,
       'notification_route': env.ST2_ROUTE || 'hubot'
     };
     var sendAck = function (res) {

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -206,11 +206,17 @@ module.exports = function(robot) {
   };
 
   var executeCommand = function(msg, command_name, format_string, command, action_alias) {
+    // Hipchat users aren't pinged by name, they're
+    // pinged by mention_name
+    var name = msg.message.user.name;
+    if (robot.adapterName == "hipchat") {
+      name = msg.message.user.mention_name;
+    };
     var payload = {
       'name': command_name,
       'format': format_string,
       'command': command,
-      'user': msg.message.user.name,
+      'user': name,
       'source_channel': msg.message.room,
       'notification_route': env.ST2_ROUTE || 'hubot'
     };

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -217,7 +217,8 @@ module.exports = function(robot) {
       'format': format_string,
       'command': command,
       'user': name,
-      'source_channel': msg.message.room || msg.message.user.reply_to,
+      'source_channel': msg.message.room,
+      'reply_to': msg.message.reply_to,
       'notification_route': env.ST2_ROUTE || 'hubot'
     };
     var sendAck = function (res) {

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -212,15 +212,18 @@ module.exports = function(robot) {
     if (robot.adapterName == "hipchat") {
       name = msg.message.user.mention_name;
     };
-    var room = msg.message.room
+    var room = msg.message.room;
+    var whisper = false;
     if (room == undefined) {
-      room = msg.message.user.jid
+      whisper = true;
+      room = msg.message.user.jid;
     }
     var payload = {
       'name': command_name,
       'format': format_string,
       'command': command,
       'user': name,
+      'whisper': whisper,
       'source_channel': room,
       'notification_route': env.ST2_ROUTE || 'hubot'
     };

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -297,7 +297,7 @@ module.exports = function(robot) {
       // is a whisper:
       if (robot.adapterName == 'hipchat' && !data.whisper && data.channel.indexOf('@') > -1 ) {
         data.whisper = true;
-        robot.logger.debug('Set whisper to true for hipchat message')
+        robot.logger.debug('Set whisper to true for hipchat message');
       }
 
       postDataHandler.postData(data);
@@ -335,7 +335,7 @@ module.exports = function(robot) {
         // is a whisper:
         if (robot.adapterName == 'hipchat' && !data.whisper && data.channel.indexOf('@') > -1 ) {
           data.whisper = true;
-          robot.logger.debug('Set whisper to true for hipchat message')
+          robot.logger.debug('Set whisper to true for hipchat message');
         }
 
         postDataHandler.postData(data);

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -212,12 +212,16 @@ module.exports = function(robot) {
     if (robot.adapterName == "hipchat") {
       name = msg.message.user.mention_name;
     };
+    var room = msg.message.room
+    if (room == undefined) {
+      room = msg.message.user.jid
+    }
     var payload = {
       'name': command_name,
       'format': format_string,
       'command': command,
       'user': name,
-      'source_channel': msg.message.room || msg.message.user.jid,
+      'source_channel': room,
       'notification_route': env.ST2_ROUTE || 'hubot'
     };
     var sendAck = function (res) {

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -297,6 +297,7 @@ module.exports = function(robot) {
       // is a whisper:
       if (robot.adapterName == 'hipchat' && !data.whisper && data.channel.indexOf('@') > -1 ) {
         data.whisper = true;
+        robot.logger.debug('Set whisper to true for hipchat message')
       }
 
       postDataHandler.postData(data);
@@ -334,6 +335,7 @@ module.exports = function(robot) {
         // is a whisper:
         if (robot.adapterName == 'hipchat' && !data.whisper && data.channel.indexOf('@') > -1 ) {
           data.whisper = true;
+          robot.logger.debug('Set whisper to true for hipchat message')
         }
 
         postDataHandler.postData(data);


### PR DESCRIPTION
Fixes: #79 

What this adds: 
* Delimiter support for text vs code for hipchat messages.
* Ability to ping users via their hipchat mention_name (user.name does not ping a user)
* Ability to have chatops functions recognize hipchat private messages and respond in the correct manner

How this was tested: 

Forked docker-hubot
Updated package.json to "hubot-stackstorm"  : "git+https://github.com/charlottestjohn/hubot-stackstorm#hipchat-postdata",
sudo docker build -t charlottetestingstuff . (inside of the docker-hubot directory, in the vagrant)
sudo vi /etc/init.d/docker-hubot
change line 71 from "stackstorm/hubot" to "charlottetestingstuff"
sudo /etc/init.d/docker-hubot restart

:cookie: Ran command w/ {~} at the end of alias notify block from chat room, verified I was pinged in the room & that nothing was in a code block
:cookie: Ran command w/ {~} at the end of alias notify block from private chat, verified that I got a message in private chat w/o my username & that nothing was in a code block
:cookie: Ran command w/ {~} in the middle of alias notify block from chat room, verified that I got 2 messages in the chat room, only one of which had my user name, and the correct messages were in the code block
:cookie: Ran command w/ {~} in the middle of alias notify block from private chat, verified that I got 2 messages in pm, none of which had my user name, and the correct messages were in the code block
:cookie: Ran command w/ no {~} in it from chat room, verified that I got 2 messages in the chat room, one with my user name and one with the code block containing all of the response
:cookie: Ran command w/ no {~} in it from private chat, verified that I got 1 message in pm, with the entire message in code, and no reference to my username