### PR TITLE
Yammer handler and support for Yammer user/message objects

### DIFF
--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -106,6 +106,39 @@ HipchatDataPostHandler.prototype.postData = function(data) {
 };
 
 /*
+  Yammer Handler.
+*/
+function YammerDataPostHandler(robot, formatter) {
+  this.robot = robot;
+  this.formatter = formatter;
+}
+
+YammerDataPostHandler.prototype.postData = function(data) {
+  var recipient, split_message, formatted_message,
+      text = "";
+
+  if (data.whisper && data.user) {
+    recipient = { name: data.user, thread_id: data.channel };
+  } else {
+    recipient = { name: data.user, thread_id: data.channel };
+    text = (data.user && !data.whisper) ? util.format('@%s: ', data.user) : "";
+  }
+
+  recipient = this.formatter.formatRecepient(recipient);
+  text += this.formatter.formatData(data.message);
+
+  // Ignore the delimiter in the default formatter and just concat parts.
+  split_message = utils.splitMessage(text);
+  if (split_message.pretext && split_message.text) {
+    formatted_message = util.format("%s\n%s", split_message.pretext, split_message.text);
+  } else {
+    formatted_message = split_message.pretext || split_message.text;
+  }
+
+  this.robot.send.call(this.robot, recipient, formatted_message);
+};
+
+/*
   DefaultDataPostHandler.
 */
 function DefaultFormatter(robot, formatter) {
@@ -141,6 +174,7 @@ DefaultFormatter.prototype.postData = function(data) {
 var dataPostHandlers = {
   'slack': SlackDataPostHandler,
   'hipchat': HipchatDataPostHandler,
+  'yammer': YammerDataPostHandler,
   'default': DefaultFormatter
 };
 

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -214,7 +214,13 @@ module.exports = function(robot) {
     };
     var room = msg.message.room;
     if (room == undefined) {
-      room = msg.message.user.jid;
+      if (robot.adapterName == "hipchat") {
+        room = msg.message.user.jid;
+      }
+    }
+    if (robot.adapterName == "yammer") {
+      room = String(msg.message.user.thread_id);
+      name = msg.message.user.name[0];
     }
     var payload = {
       'name': command_name,


### PR DESCRIPTION
This makes st2 support Yammer through the `hubot-yammer` module. A bot can join pre-defined groups, and reply to new messages as well as comments.

`hubot-yammer` doesn’t support PMs though, so you can’t chat with the bot, and that’s kinda sad, but rooms should be enough for most uses. After all, you can create a private room for a bot.

Since we don’t have Yammer in the installer, a (very simple) manual modification of the `docker-hubot` init script would be required, so we can consider this experimental for now.

Also see https://github.com/StackStorm/docker-hubot/pull/6