### PR TITLE
Allow specifying color for Slack messages

### DIFF
--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -40,9 +40,13 @@ SlackDataPostHandler.prototype.postData = function(data) {
     pretext = (data.user && !data.whisper) ? util.format('@%s: ', data.user) : "";
   }
 
-  attachment_color = env.ST2_SLACK_SUCCESS_COLOR;
-  if (data.message.indexOf("status : failed") > -1) {
-    attachment_color = env.ST2_SLACK_FAIL_COLOR;
+  if (data.color) {
+    attachment_color = data.color
+  } else {
+    attachment_color = env.ST2_SLACK_SUCCESS_COLOR;
+    if (data.message.indexOf("status : failed") > -1) {
+      attachment_color = env.ST2_SLACK_FAIL_COLOR;
+    }
   }
 
   split_message = utils.splitMessage(this.formatter.formatData(data.message));


### PR DESCRIPTION
This commit allows specifying a color for the Slack "attachment". It falls back on the old logic if no color is specified with the message.