### PR TITLE
Changing the regex to match the full command line

### DIFF
--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -50,10 +50,10 @@ CommandFactory.prototype.getRegexForFormatString = function(format) {
   // be skipped.
   // Note that we use "[\s\S]" instead of "." to allow multi-line values
   // and multi-line commands in general.
-  extra_params = '(\\s+(\\S+)\\s*=("([\\s\\S]*?)"|\'([\\s\\S]*?)\'|({[\\s\\S]*?})|(\\S+))\\s*)*$';
+  extra_params = '(\\s+(\\S+)\\s*=("([\\s\\S]*?)"|\'([\\s\\S]*?)\'|({[\\s\\S]*?})|(\\S+))\\s*)*';
   regex_str = format.replace(/(\s*){{\s*\S+\s*=\s*(?:({.+?}|.+?))\s*}}(\s*)/g, '\\s*($1([\\s\\S]+?)$3)?\\s*');
   regex_str = regex_str.replace(/\s*{{.+?}}\s*/g, '\\s*([\\s\\S]+?)\\s*');
-  regex = new RegExp(regex_str + extra_params);
+  regex = new RegExp('^\\s*' + regex_str + extra_params + '\\s*$');
   return regex;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-stackstorm",
   "description": "A hubot plugin for integrating with StackStorm event-driven infrastructure automation platform.",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "author": "StackStorm, Inc. <info@stackstorm.com>",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
Fixes #92

There was a bug in command matching that would match a valid command preceded by any text (i.e. `aaast2 list actions` would match `st2 list actions`). Parser on the back-end doesn’t have this issue, so it receives the command, can’t match any parameters and executes it with defaults.

This PR makes hubot only match the full string as it should.