### PR TITLE
Avoid calling `getRegexForFormatString` for `display` parameters

### DIFF
--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -73,14 +73,14 @@ CommandFactory.prototype.addCommand = function(command, name, format, action_ali
   compiled_template = _.template('hubot ${command}');
   command_string = compiled_template(context);
 
-  regex = this.getRegexForFormatString(format);
-  this.st2_hubot_commands.push(command_string);
-  this.st2_commands_name_map[name] = action_alias;
-  this.st2_commands_format_map[format] = action_alias;
   if (!flag || flag === utils.DISPLAY) {
     this.robot.commands.push(command_string);
   }
   if (!flag || flag === utils.REPRESENTATION) {
+    this.st2_hubot_commands.push(command_string);
+    this.st2_commands_name_map[name] = action_alias;
+    this.st2_commands_format_map[format] = action_alias;
+    regex = this.getRegexForFormatString(format);
     this.st2_commands_regex_map[format] = regex;
   }
 


### PR DESCRIPTION
Fixes #94

There’s a bug that makes a `display` string, which is meant solely for
appearing in Hubot’s help, to go through the same transformations as
normal commands, which means it will be converted to a regex. It’s not
just unnecessary, but actually causes an error in some cases.