### PR TITLE
Hotfix: avoid duplicating help entries

### DIFF
--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -73,15 +73,15 @@ CommandFactory.prototype.addCommand = function(command, name, format, action_ali
   compiled_template = _.template('hubot ${command}');
   command_string = compiled_template(context);
 
-  if (!flag || flag === utils.DISPLAY) {
-    this.robot.commands.push(command_string);
-  }
   if (!flag || flag === utils.REPRESENTATION) {
     this.st2_hubot_commands.push(command_string);
     this.st2_commands_name_map[name] = action_alias;
     this.st2_commands_format_map[format] = action_alias;
     regex = this.getRegexForFormatString(format);
     this.st2_commands_regex_map[format] = regex;
+  }
+  if ((!flag || flag === utils.DISPLAY) && this.robot.commands.indexOf(command_string) === -1) {
+    this.robot.commands.push(command_string);
   }
 
   this.robot.logger.debug('Added command: ' + command);


### PR DESCRIPTION
In some cases with `display/representation` aliases help entries might
duplicate. This is a simple fix checking if the entry is already in the
array.