### PR TITLE
Match commands ignoring case

### DIFF
--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -53,7 +53,7 @@ CommandFactory.prototype.getRegexForFormatString = function(format) {
   extra_params = '(\\s+(\\S+)\\s*=("([\\s\\S]*?)"|\'([\\s\\S]*?)\'|({[\\s\\S]*?})|(\\S+))\\s*)*';
   regex_str = format.replace(/(\s*){{\s*\S+\s*=\s*(?:({.+?}|.+?))\s*}}(\s*)/g, '\\s*($1([\\s\\S]+?)$3)?\\s*');
   regex_str = regex_str.replace(/\s*{{.+?}}\s*/g, '\\s*([\\s\\S]+?)\\s*');
-  regex = new RegExp('^\\s*' + regex_str + extra_params + '\\s*$');
+  regex = new RegExp('^\\s*' + regex_str + extra_params + '\\s*$', 'i');
   return regex;
 };
 

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -274,9 +274,7 @@ module.exports = function(robot) {
     // e.g. slack replace quote marks with left double quote which would break behavior.
     command = formatter.normalizeCommand(msg.match[1]);
 
-    // Use the lower-case version only for lookup. Other preserve the case so that
-    // user provided case is preserved.
-    result = command_factory.getMatchingCommand(command.toLowerCase());
+    result = command_factory.getMatchingCommand(command);
 
     if (!result) {
       // No command found


### PR DESCRIPTION
As planned originally, commands are now matched in a case-insensitive
way; it’s achieved with the `i` flag instead of converting to
lowercase, because the latter is error-prone.

Fixes https://github.com/StackStorm/st2/issues/2566