### PR TITLE
Support `extra:color` and `extra:slack`

### DIFF
--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -31,7 +31,7 @@ function SlackDataPostHandler(robot, formatter) {
 
 SlackDataPostHandler.prototype.postData = function(data) {
   var recipient, attachment_color, split_message,
-      pretext = "";
+      attachment, pretext = "";
 
   if (data.whisper && data.user) {
     recipient = data.user;
@@ -40,8 +40,8 @@ SlackDataPostHandler.prototype.postData = function(data) {
     pretext = (data.user && !data.whisper) ? util.format('@%s: ', data.user) : "";
   }
 
-  if (data.color) {
-    attachment_color = data.color
+  if (data.extra && data.extra.color) {
+    attachment_color = data.extra.color
   } else {
     attachment_color = env.ST2_SLACK_SUCCESS_COLOR;
     if (data.message.indexOf("status : failed") > -1) {
@@ -52,15 +52,19 @@ SlackDataPostHandler.prototype.postData = function(data) {
   split_message = utils.splitMessage(this.formatter.formatData(data.message));
 
   if (split_message.text) {
+    attachment = {
+      color: attachment_color,
+      text: split_message.text,
+      "mrkdwn_in": ["text", "pretext"],
+      fallback: split_message.text
+    }
+    if (data.extra && data.extra.slack) {
+      for (var attrname in data.extra.slack) { attachment[attrname] = data.extra.slack[attrname] }
+    }
     this.robot.emit('slack-attachment', {
       channel: recipient,
       text: pretext + split_message.pretext,
-      content: {
-        color: attachment_color,
-        text: split_message.text,
-        "mrkdwn_in": ["text", "pretext"],
-        fallback: split_message.text
-      }
+      content: attachment
     });
   } else {
     this.robot.messageRoom.call(this.robot, recipient, pretext + split_message.pretext);


### PR DESCRIPTION
Add support for a few `extra` parameters:
1. `color` will set the attachment color in Slack.
2. `slack` object will be passed to `attachment.emit` as is, so it can be populated according to the attachment docs at https://api.slack.com/docs/attachments

It degrades gracefully: if there’s no `extra`, no additional parameters are added. If there’s a different adapter, no additional processing takes place.

This is supposed to go together with https://github.com/StackStorm/st2/pull/2572, but can be merged earlier.