### PR TITLE
[RFR] Native support for two-factor auth

### DIFF
--- a/lib/format_data.js
+++ b/lib/format_data.js
@@ -73,7 +73,7 @@ HipChatFormatter.prototype.formatData = function(data) {
 
 HipChatFormatter.prototype.formatRecepient = function(recepient) {
   var robot_name = env.HUBOT_HIPCHAT_JID.split("_")[0];
-  var hipchat_domain = (env.HUBOT_HIPCHAT_XMPP_DOMAIN == 'btf.hipchat.com') ?
+  var hipchat_domain = (env.HUBOT_HIPCHAT_XMPP_DOMAIN === 'btf.hipchat.com') ?
                        'conf.btf.hipchat.com' : 'conf.hipchat.com';
   return util.format('%s_%s@%s', robot_name, recepient, hipchat_domain);
 };

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -41,7 +41,7 @@ SlackDataPostHandler.prototype.postData = function(data) {
   }
 
   if (data.color) {
-    attachment_color = data.color
+    attachment_color = data.color;
   } else {
     attachment_color = env.ST2_SLACK_SUCCESS_COLOR;
     if (data.message.indexOf("status : failed") > -1) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,10 +82,17 @@ function splitMessage(message) {
   };
 }
 
+function enable2FA(action_alias) {
+  return env.HUBOT_2FA &&
+         action_alias.extra && action_alias.extra.security &&
+         action_alias.extra.security.twofactor !== undefined;
+}
+
 
 exports.isNull = isNull;
 exports.getExecutionHistoryUrl = getExecutionHistoryUrl;
 exports.parseUrl = parseUrl;
 exports.splitMessage = splitMessage;
+exports.enable2FA = enable2FA;
 exports.DISPLAY = DISPLAY;
 exports.REPRESENTATION = REPRESENTATION;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "cli-table": "<=1.0.0",
     "rsvp": "3.0.14",
     "st2client": "^0.4.3",
-    "truncate": "^1.0.4"
+    "truncate": "^1.0.4",
+    "node-uuid": "~1.4.0"
   },
   "peerDependencies": {
     "hubot": "2.x"

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -91,8 +91,8 @@ var ERROR_MESSAGES = [
   "I'm sorry, Dave. I'm afraid I can't do that. (%s)"
 ];
 
-var TWOFACTOR_MESSAGE = "This action requires two-factor authentication!" +
-                        "Auth with Duo Security: `%s2fa %s`";
+var TWOFACTOR_MESSAGE = "This action requires two-factor auth!\n" +
+                        "Authenticate with Duo Security: `%s 2fa %s`";
 
 
 module.exports = function(robot) {
@@ -242,7 +242,7 @@ module.exports = function(robot) {
       .catch(function (err) {
         // Compatibility with older StackStorm versions
         if (err.status === 200) {
-          return sendAck({ execution: { id: err.message } });
+          return sendAck(msg, { execution: { id: err.message } });
         }
         robot.logger.error('Failed to create an alias execution:', err);
         msg.send(util.format(_.sample(ERROR_MESSAGES), err.message));
@@ -278,10 +278,10 @@ module.exports = function(robot) {
 
     if (env.HUBOT_2FA && action_alias.extra && action_alias.extra.security &&
         action_alias.extra.security.twofactor !== undefined) {
-      var uuid = uuid.v4();
-      robot.logger.debug('Requested an action that requires 2FA. Guid: ' + uuid);
-      msg.send(util.format(TWOFACTOR_MESSAGE, [robot.alias, uuid]));
-      twofactor[uuid] = {
+      var twofactor_id = uuid.v4();
+      robot.logger.debug('Requested an action that requires 2FA. Guid: ' + twofactor_id);
+      msg.send(util.format(TWOFACTOR_MESSAGE, robot.alias, twofactor_id));
+      twofactor[twofactor_id] = {
         'msg': msg,
         'payload': payload
       };

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -91,8 +91,10 @@ var ERROR_MESSAGES = [
   "I'm sorry, Dave. I'm afraid I can't do that. (%s)"
 ];
 
-var TWOFACTOR_MESSAGE = "This action requires two-factor auth!\n" +
-                        "Authenticate with Duo Security: `%s 2fa %s`";
+var TWOFACTOR_MESSAGE = "This action requires two-factor auth! Authenticate with Duo Security:\n" +
+                        "```\n" +
+                        "%s 2fa %s\n" +
+                        "```";
 
 
 module.exports = function(robot) {

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -283,7 +283,10 @@ module.exports = function(robot) {
       api.executions.create({
         'action': env.HUBOT_2FA,
         'parameters': {
-          'uuid': twofactor_id
+          'uuid': twofactor_id,
+          'user': name,
+          'channel': room,
+          'hint': action_alias.description
         }
       });
       twofactor[twofactor_id] = {

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -160,6 +160,7 @@ module.exports = function(robot) {
   // Pending 2-factor auth commands
   if (env.HUBOT_2FA) {
     var twofactor = {};
+    robot.logger.info('Two-factor auth is enabled');
   }
 
   // factory to manage commands
@@ -275,8 +276,7 @@ module.exports = function(robot) {
       'notification_route': env.ST2_ROUTE || 'hubot'
     };
 
-    if (env.HUBOT_2FA && action_alias.extra && action_alias.extra.security &&
-        action_alias.extra.security.twofactor !== undefined) {
+    if (utils.enable2FA(action_alias)) {
       var twofactor_id = uuid.v4();
       robot.logger.debug('Requested an action that requires 2FA. Guid: ' + twofactor_id);
       msg.send(TWOFACTOR_MESSAGE);

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -253,16 +253,16 @@ module.exports = function(robot) {
     // Hipchat users aren't pinged by name, they're
     // pinged by mention_name
     var name = msg.message.user.name;
-    if (robot.adapterName == "hipchat") {
+    if (robot.adapterName === "hipchat") {
       name = msg.message.user.mention_name;
     }
     var room = msg.message.room;
     if (room === undefined) {
-      if (robot.adapterName == "hipchat") {
+      if (robot.adapterName === "hipchat") {
         room = msg.message.user.jid;
       }
     }
-    if (robot.adapterName == "yammer") {
+    if (robot.adapterName === "yammer") {
       room = String(msg.message.user.thread_id);
       name = msg.message.user.name[0];
     }
@@ -332,7 +332,7 @@ module.exports = function(robot) {
       }
       // Special handler to try and figure out when a hipchat message
       // is a whisper:
-      if (robot.adapterName == 'hipchat' && !data.whisper && data.channel.indexOf('@') > -1 ) {
+      if (robot.adapterName === 'hipchat' && !data.whisper && data.channel.indexOf('@') > -1 ) {
         data.whisper = true;
         robot.logger.debug('Set whisper to true for hipchat message');
       }
@@ -370,7 +370,7 @@ module.exports = function(robot) {
 
         // Special handler to try and figure out when a hipchat message
         // is a whisper:
-        if (robot.adapterName == 'hipchat' && !data.whisper && data.channel.indexOf('@') > -1 ) {
+        if (robot.adapterName === 'hipchat' && !data.whisper && data.channel.indexOf('@') > -1 ) {
           data.whisper = true;
           robot.logger.debug('Set whisper to true for hipchat message');
         }

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -91,10 +91,7 @@ var ERROR_MESSAGES = [
   "I'm sorry, Dave. I'm afraid I can't do that. (%s)"
 ];
 
-var TWOFACTOR_MESSAGE = "This action requires two-factor auth! Authenticate with Duo Security:\n" +
-                        "```\n" +
-                        "%s 2fa %s\n" +
-                        "```";
+var TWOFACTOR_MESSAGE = "This action requires two-factor auth! Waiting for your confirmation.";
 
 
 module.exports = function(robot) {
@@ -282,7 +279,13 @@ module.exports = function(robot) {
         action_alias.extra.security.twofactor !== undefined) {
       var twofactor_id = uuid.v4();
       robot.logger.debug('Requested an action that requires 2FA. Guid: ' + twofactor_id);
-      msg.send(util.format(TWOFACTOR_MESSAGE, robot.alias, twofactor_id));
+      msg.send(TWOFACTOR_MESSAGE);
+      api.executions.create({
+        'action': env.HUBOT_2FA,
+        'parameters': {
+          'uuid': twofactor_id
+        }
+      });
       twofactor[twofactor_id] = {
         'msg': msg,
         'payload': payload

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -387,6 +387,7 @@ module.exports = function(robot) {
 
           var executionData = twofactor[data.uuid];
           createExecution(executionData.msg, executionData.payload);
+          delete twofactor[data.uuid];
 
         });
       }

--- a/tests/fixtures/aliases.json
+++ b/tests/fixtures/aliases.json
@@ -24,4 +24,15 @@
     "alias4 fmt1 {{param1}} word {{param2}}",
     "alias4 fmt1 {{param1}}"
   ]
+}, {
+  "name": "twofactor",
+  "description": "alias with two-factor auth",
+  "formats": [
+    "alias5 fmt1"
+  ],
+  "extra": {
+    "security": {
+      "twofactor": true
+    }
+  }
 }]

--- a/tests/test-2fa.js
+++ b/tests/test-2fa.js
@@ -31,13 +31,11 @@ var expect = require("chai").expect,
 var disableLogger = true,
   controlledLogger = function(msg) {};
 
-var disableAuth = function() {
-  process.env.ST2_AUTH_URL = '';
-  process.env.ST2_AUTH_USERNAME = '';
-  process.env.ST2_AUTH_PASSWORD = '';
+var enableTwofactor = function() {
+  process.env.HUBOT_2FA = 'somepack.twofactor_action';
 };
 
-describe("stanley the StackStorm bot", function() {
+describe("two-factor auth module", function() {
   var robot, user, adapter, st2bot, stop;
 
   before(function(done) {
@@ -51,7 +49,7 @@ describe("stanley the StackStorm bot", function() {
       robot.logger.debug = controlledLogger;
     }
 
-    disableAuth();
+    enableTwofactor();
 
     robot.adapter.on("connected", function() {
 
@@ -85,20 +83,28 @@ describe("stanley the StackStorm bot", function() {
     robot.shutdown();
   });
 
-  it("responds when asked for help", function(done) {
-    adapter.on("send", function(envelope, strings) {
-      expect(strings[0]).to.be.a('string');
-      done();
-    });
-    adapter.receive(new TextMessage(user, "Hubot help"));
+  it("is enabled when HUBOT_2FA is set", function(done) {
+    expect(st2bot.twofactor).to.be.an('object');
   });
 
-  it("has listeners", function() {
-    expect(robot.listeners).to.have.length(2);
+  it("is fired up when an alias has `extra:security:twofactor`", function(done) {
+    return false;
   });
 
-  it("doesn't have two-factor auth enabled by default", function() {
-    expect(st2bot.twofactor).to.be.an('undefined');
+  it("is not fired up when an alias has `extra:security:twofactor`", function(done) {
+    return false;
+  });
+
+  it("is authenticated when 2fa event with the right uuid is passed", function(done) {
+    return false;
+  });
+
+  it("does nothing when an event with a wrong uuid is received", function(done) {
+    return false;
+  });
+
+  it("does not approve the same event twice", function(done) {
+    return false;
   });
 
 });

--- a/tests/test-st2bot-setup.js
+++ b/tests/test-st2bot-setup.js
@@ -29,7 +29,8 @@ var expect = require("chai").expect,
   TextMessage = require("hubot/src/message").TextMessage;
 
 var disableLogger = true,
-  controlledLogger = function(msg) {};
+    logs = [],
+    controlledLogger = function(msg) { logs.push(msg); };
 
 var disableAuth = function() {
   process.env.ST2_AUTH_URL = '';
@@ -98,7 +99,7 @@ describe("stanley the StackStorm bot", function() {
   });
 
   it("doesn't have two-factor auth enabled by default", function() {
-    expect(st2bot.twofactor).to.be.an('undefined');
+    expect(logs).not.to.contain('Two-factor auth is enabled');
   });
 
 });

--- a/tests/test-twofactor.js
+++ b/tests/test-twofactor.js
@@ -102,26 +102,14 @@ describe("two-factor auth module", function() {
   });
 
   it("is fired up when an alias has `extra:security:twofactor`", function() {
-    // expect(utils.enable2FA(ALIAS_FIXTURES[4])).to.be.ok;
+    expect(utils.enable2FA(ALIAS_FIXTURES[4])).to.be.ok;
   });
 
   it("is not fired up when an alias has no `extra:security:twofactor`", function() {
-    // expect(utils.enable2FA(ALIAS_FIXTURES[0])).to.be.not.ok;
-    // expect(utils.enable2FA(ALIAS_FIXTURES[1])).to.be.not.ok;
-    // expect(utils.enable2FA(ALIAS_FIXTURES[2])).to.be.not.ok;
-    // expect(utils.enable2FA(ALIAS_FIXTURES[3])).to.be.not.ok;
-  });
-
-  it("is approved when a `2fa` event with the right uuid is passed", function() {
-
-  });
-
-  it("does nothing when an event with a wrong uuid is received", function() {
-
-  });
-
-  it("does not approve the same event twice", function() {
-
+    expect(utils.enable2FA(ALIAS_FIXTURES[0])).to.be.not.ok;
+    expect(utils.enable2FA(ALIAS_FIXTURES[1])).to.be.not.ok;
+    expect(utils.enable2FA(ALIAS_FIXTURES[2])).to.be.not.ok;
+    expect(utils.enable2FA(ALIAS_FIXTURES[3])).to.be.not.ok;
   });
 
 });

--- a/tests/test-twofactor.js
+++ b/tests/test-twofactor.js
@@ -23,20 +23,28 @@ limitations under the License.
 // needed to get all coffeescript modules to be loaded
 require('coffee-script/register');
 
-var expect = require("chai").expect,
-  path = require("path"),
-  Robot = require("hubot/src/robot"),
-  TextMessage = require("hubot/src/message").TextMessage;
+var fs = require('fs'),
+    expect = require("chai").expect,
+    path = require("path"),
+    Robot = require("hubot/src/robot"),
+    TextMessage = require("hubot/src/message").TextMessage,
+    CommandFactory = require('../lib/command_factory.js'),
+    formatCommand = require('../lib/format_command.js'),
+    utils = require('../lib/utils.js');
+
+var ALIAS_FIXTURES = fs.readFileSync('tests/fixtures/aliases.json');
+ALIAS_FIXTURES = JSON.parse(ALIAS_FIXTURES);
 
 var disableLogger = true,
-  controlledLogger = function(msg) {};
+    logs = [],
+    controlledLogger = function(msg) { logs.push(msg); };
 
 var enableTwofactor = function() {
   process.env.HUBOT_2FA = 'somepack.twofactor_action';
 };
 
 describe("two-factor auth module", function() {
-  var robot, user, adapter, st2bot, stop;
+  var robot, user, adapter, st2bot, stop, command_factory;
 
   before(function(done) {
     robot = new Robot(null, "mock-adapter", true, "Hubot");
@@ -67,7 +75,16 @@ describe("two-factor auth module", function() {
         });
 
         adapter = robot.adapter;
+        command_factory = new CommandFactory(robot);
+        ALIAS_FIXTURES.forEach(function(alias) {
+          command_factory.addCommand(
+            formatCommand(null, alias.name, alias.formats[0], alias.description),
+            alias.name,
+            alias.formats[0],
+            alias);
+        });
         done();
+
       }).catch(function(err) {
         console.log(err);
         done(err);
@@ -81,30 +98,30 @@ describe("two-factor auth module", function() {
     stop && stop();
     robot.server.close();
     robot.shutdown();
+    logs = [];
   });
 
-  it("is enabled when HUBOT_2FA is set", function(done) {
-    expect(st2bot.twofactor).to.be.an('object');
+  it("is fired up when an alias has `extra:security:twofactor`", function() {
+    // expect(utils.enable2FA(ALIAS_FIXTURES[4])).to.be.ok;
   });
 
-  it("is fired up when an alias has `extra:security:twofactor`", function(done) {
-    return false;
+  it("is not fired up when an alias has no `extra:security:twofactor`", function() {
+    // expect(utils.enable2FA(ALIAS_FIXTURES[0])).to.be.not.ok;
+    // expect(utils.enable2FA(ALIAS_FIXTURES[1])).to.be.not.ok;
+    // expect(utils.enable2FA(ALIAS_FIXTURES[2])).to.be.not.ok;
+    // expect(utils.enable2FA(ALIAS_FIXTURES[3])).to.be.not.ok;
   });
 
-  it("is not fired up when an alias has `extra:security:twofactor`", function(done) {
-    return false;
+  it("is approved when a `2fa` event with the right uuid is passed", function() {
+
   });
 
-  it("is authenticated when 2fa event with the right uuid is passed", function(done) {
-    return false;
+  it("does nothing when an event with a wrong uuid is received", function() {
+
   });
 
-  it("does nothing when an event with a wrong uuid is received", function(done) {
-    return false;
-  });
+  it("does not approve the same event twice", function() {
 
-  it("does not approve the same event twice", function(done) {
-    return false;
   });
 
 });


### PR DESCRIPTION
Goes together with https://github.com/StackStorm/st2contrib/pull/444.

This PR adds native support for two-factor auth through the Duo pack. Support can be enabled by setting `HUBOT_2FA` environment variable and having `extra:security:twofactor` flag in an alias. 

It works through “freezing” an execution attempt until a `2fa` announcement for a successful auth with the correspondent ID is caught in the stream.

The change is fully backwards-compatible; later I’ll add the env variable (commented out) to `st2chatops.env`, thoroughly documenting the case as well.