### PR TITLE
Prettify error messages on incorrect executions

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -88,11 +88,38 @@ function enable2FA(action_alias) {
          action_alias.extra.security.twofactor !== undefined;
 }
 
+function normalizeAddressee(msg) {
+  var name = msg.message.user.name;
+  if (robot.adapterName === "hipchat") {
+    // Hipchat users aren't pinged by name, they're
+    // pinged by mention_name
+    name = msg.message.user.mention_name;
+  }
+  var room = msg.message.room;
+  if (room === undefined) {
+    if (robot.adapterName === "hipchat") {
+      room = msg.message.user.jid;
+    }
+  }
+  if (robot.adapterName === "yammer") {
+    room = String(msg.message.user.thread_id);
+    name = msg.message.user.name[0];
+  }
+  if (robot.adapterName === "spark") {
+    room = msg.message.user.room;
+    name = msg.message.user.name;
+  }
+  return {
+    name: name,
+    room: room
+  };
+}
 
 exports.isNull = isNull;
 exports.getExecutionHistoryUrl = getExecutionHistoryUrl;
 exports.parseUrl = parseUrl;
 exports.splitMessage = splitMessage;
 exports.enable2FA = enable2FA;
+exports.normalizeAddressee = normalizeAddressee;
 exports.DISPLAY = DISPLAY;
 exports.REPRESENTATION = REPRESENTATION;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -88,24 +88,24 @@ function enable2FA(action_alias) {
          action_alias.extra.security.twofactor !== undefined;
 }
 
-function normalizeAddressee(msg) {
+function normalizeAddressee(msg, adapter) {
   var name = msg.message.user.name;
-  if (robot.adapterName === "hipchat") {
+  if (adapter === "hipchat") {
     // Hipchat users aren't pinged by name, they're
     // pinged by mention_name
     name = msg.message.user.mention_name;
   }
   var room = msg.message.room;
   if (room === undefined) {
-    if (robot.adapterName === "hipchat") {
+    if (adapter === "hipchat") {
       room = msg.message.user.jid;
     }
   }
-  if (robot.adapterName === "yammer") {
+  if (adapter === "yammer") {
     room = String(msg.message.user.thread_id);
     name = msg.message.user.name[0];
   }
-  if (robot.adapterName === "spark") {
+  if (adapter === "spark") {
     room = msg.message.user.room;
     name = msg.message.user.name;
   }

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -245,7 +245,7 @@ module.exports = function(robot) {
           return sendAck(msg, { execution: { id: err.message } });
         }
         robot.logger.error('Failed to create an alias execution:', err);
-        var addressee = utils.normalizeAddressee(msg);
+        var addressee = utils.normalizeAddressee(msg, robot.adapterName);
         postDataHandler.postData({
           whisper: false,
           user: addressee.name,
@@ -260,7 +260,7 @@ module.exports = function(robot) {
     };
 
   var executeCommand = function(msg, command_name, format_string, command, action_alias) {
-    var addressee = utils.normalizeAddressee(msg);
+    var addressee = utils.normalizeAddressee(msg, robot.adapterName);
     var payload = {
       'name': command_name,
       'format': format_string,

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -88,7 +88,7 @@ var START_MESSAGES = [
 ];
 
 var ERROR_MESSAGES = [
-  "I'm sorry, Dave. I'm afraid I can't do that. (%s)"
+  "I'm sorry, Dave. I'm afraid I can't do that. {~} %s"
 ];
 
 var TWOFACTOR_MESSAGE = "This action requires two-factor auth! Waiting for your confirmation.";
@@ -245,7 +245,16 @@ module.exports = function(robot) {
           return sendAck(msg, { execution: { id: err.message } });
         }
         robot.logger.error('Failed to create an alias execution:', err);
-        msg.send(util.format(_.sample(ERROR_MESSAGES), err.message));
+        var addressee = utils.normalizeAddressee(msg);
+        postDataHandler.postData({
+          whisper: false,
+          user: addressee.name,
+          channel: addressee.room,
+          message: util.format(_.sample(ERROR_MESSAGES), err.message),
+          extra: {
+            color: '#F35A00'
+          }
+        });
         throw err;
       });
     };

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -251,32 +251,13 @@ module.exports = function(robot) {
     };
 
   var executeCommand = function(msg, command_name, format_string, command, action_alias) {
-    // Hipchat users aren't pinged by name, they're
-    // pinged by mention_name
-    var name = msg.message.user.name;
-    if (robot.adapterName === "hipchat") {
-      name = msg.message.user.mention_name;
-    }
-    var room = msg.message.room;
-    if (room === undefined) {
-      if (robot.adapterName === "hipchat") {
-        room = msg.message.user.jid;
-      }
-    }
-    if (robot.adapterName === "yammer") {
-      room = String(msg.message.user.thread_id);
-      name = msg.message.user.name[0];
-    }
-    if (robot.adapterName === "spark") {
-      room = msg.message.user.room;
-      name = msg.message.user.name;
-    }
+    var addressee = utils.normalizeAddressee(msg);
     var payload = {
       'name': command_name,
       'format': format_string,
       'command': command,
-      'user': name,
-      'source_channel': room,
+      'user': addressee.name,
+      'source_channel': addressee.room,
       'notification_route': env.ST2_ROUTE || 'hubot'
     };
 
@@ -288,8 +269,8 @@ module.exports = function(robot) {
         'action': env.HUBOT_2FA,
         'parameters': {
           'uuid': twofactor_id,
-          'user': name,
-          'channel': room,
+          'user': addressee.name,
+          'channel': addressee.room,
           'hint': action_alias.description
         }
       });


### PR DESCRIPTION
Error messages that Hubot posts on incorrect executions (the most common case is schema validation error in an alias) were previously sent to chat as plaintext, which is messy since the messages tend to get quite long. 

This PR makes those messages go through the same formatting process as our usual result messages do: e.g. in Slack it would result in prettified and truncated attachment with a red-colored strip.

Thanks to @Kami for ranting about this convincingly enough. 😛 

![screenshot 2016-04-13 07 45 13](https://cloud.githubusercontent.com/assets/145218/14480550/53ec4b3c-0154-11e6-928f-7a8b0f38b395.png)
