### PR TITLE
Catch all response sc.15.4.16

### DIFF
--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -243,6 +243,11 @@ module.exports = function(robot) {
       }
 
       if (res.message) {
+        var msgs = (res.message + history).split('|');
+        if (msgs.length > 1) {
+          return msg.send(msg.random(msgs));
+        }
+
         return msg.send(res.message + history);
       }
 

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -284,7 +284,9 @@ module.exports = function(robot) {
     result = command_factory.getMatchingCommand(command.toLowerCase());
 
     if (!result) {
-      // No command found
+      //add a default response if the command is not found
+      msg.send("I'm sorry but I didn't recognise that command. Please try !help for available commands.");
+      // No command found, notifiy slack user
       return;
     }
 


### PR DESCRIPTION
At present there is no default message when a command is not recognised so it fails silently. It would be more user friendly to send a simple message to inform the user that the command was not recognised so that they can check and try again.

A CatchAll can be added via an additional Coffee script but I found that once hubot-stackstorm was installed it only worked with general messages and not those directed to Hubot. 
