### PR TITLE
Separate long Slack attachment into chunks

### DIFF
--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -71,7 +71,7 @@ SlackDataPostHandler.prototype.postData = function(data) {
       };
       robot.emit('slack-attachment', attachment);
       if (chunks.length > ++i) {
-        sendChunk(i);
+        setTimeout(function(){ sendChunk(i); }, 300);
       }
     };
     sendChunk(0);

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -52,20 +52,24 @@ SlackDataPostHandler.prototype.postData = function(data) {
   split_message = utils.splitMessage(this.formatter.formatData(data.message));
 
   if (split_message.text) {
-    attachment = {
+    var content = {
       color: attachment_color,
-      text: split_message.text,
       "mrkdwn_in": ["text", "pretext"],
-      fallback: split_message.text
     };
     if (data.extra && data.extra.slack) {
-      for (var attrname in data.extra.slack) { attachment[attrname] = data.extra.slack[attrname]; }
+      for (var attrname in data.extra.slack) { content[attrname] = data.extra.slack[attrname]; }
     }
-    this.robot.emit('slack-attachment', {
-      channel: recipient,
-      text: pretext + split_message.pretext,
-      content: attachment
-    });
+    var chunks = split_message.text.match(/[\s\S]{1,7900}/g);
+    for (var i = 0; i < chunks.length; i++) {
+      content.text = chunks[i];
+      content.fallback = chunks[i];
+      attachment = {
+        channel: recipient,
+        content: content,
+        text: i === 0 ? pretext + split_message.pretext : null
+      };
+      this.robot.emit('slack-attachment', attachment);
+    }
   } else {
     this.robot.messageRoom.call(this.robot, recipient, pretext + split_message.pretext);
   }

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -59,8 +59,9 @@ SlackDataPostHandler.prototype.postData = function(data) {
     if (data.extra && data.extra.slack) {
       for (var attrname in data.extra.slack) { content[attrname] = data.extra.slack[attrname]; }
     }
+    var robot = this.robot;
     var chunks = split_message.text.match(/[\s\S]{1,7900}/g);
-    for (var i = 0; i < chunks.length; i++) {
+    var sendChunk = function (i) {
       content.text = chunks[i];
       content.fallback = chunks[i];
       attachment = {
@@ -68,8 +69,12 @@ SlackDataPostHandler.prototype.postData = function(data) {
         content: content,
         text: i === 0 ? pretext + split_message.pretext : null
       };
-      this.robot.emit('slack-attachment', attachment);
-    }
+      robot.emit('slack-attachment', attachment);
+      if (chunks.length > ++i) {
+        sendChunk(i);
+      }
+    };
+    sendChunk(0);
   } else {
     this.robot.messageRoom.call(this.robot, recipient, pretext + split_message.pretext);
   }


### PR DESCRIPTION
Fixes #108.

As reported by @jmound, long attachments (over 8000 characters long to be precise) are cut by Slack without an error or exception, so we have to catch those and split into multiple separate attachments. I couldn’t find a reference to this behavior in Slack docs, but could find workarounds in other’s Slack-involving code, so it’s seems to be a common method of dealing with the problem.

Long plaintext messages are split by Slack automatically.

Extra formatting (colors, etc.) is added to every chunk. 

Plaintext (where present) is only added to the first chunk.