### PR TITLE
Allow multiple extra attachments

### DIFF
--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -50,7 +50,10 @@ SlackDataPostHandler.prototype.postData = function(data) {
   }
 
   split_message = utils.splitMessage(this.formatter.formatData(data.message));
-
+  var attachments = [];
+  if (data.extra && data.extra.slack && data.extra.slack.attachments) {
+	   for(var i=0, len=data.extra.slack.attachments.length; i < len; i++) { attachments.push(data.extra.slack.attachments[i]); }
+  }  
   if (split_message.text) {
     attachment = {
       color: attachment_color,
@@ -58,18 +61,21 @@ SlackDataPostHandler.prototype.postData = function(data) {
       "mrkdwn_in": ["text", "pretext"],
       fallback: split_message.text
     };
-    if (data.extra && data.extra.slack) {
-      for (var attrname in data.extra.slack) { attachment[attrname] = data.extra.slack[attrname]; }
+    if (data.extra && data.extra.slack && data.extra.slack.content) {
+      for (var attrname in data.extra.slack.content) { attachment[attrname] = data.extra.slack.content[attrname]; }
     }
-    this.robot.emit('slack-attachment', {
-      channel: recipient,
-      text: pretext + split_message.pretext,
-      content: attachment
-    });
+    attachments.unshift(attachment);
   } else {
     this.robot.messageRoom.call(this.robot, recipient, pretext + split_message.pretext);
   }
+    if ( attachments.length > 0 ) {
+      this.robot.emit('slack-attachment', {
+        channel: recipient,
+        content: attachments
+     });    	
+    }  
 };
+
 
 /*
   HipchatDataPostHandler.


### PR DESCRIPTION
This PR does some modifications to how attachments work on slack so you can send multiple attachments. You can do things like:

```
result:
  format: "{{ execution.result.stdout }} {~}"
  extra:
    slack:
      attachments:
        - color: "#1100ff"
          fallback: "Required plain-text summary of the attachment number 2."
          pretext: "Optional text that appears above the attachment block number 2"
          author_name: "Bobby Tables number 2"
          author_link: "http://flickr.com/bobby/"
          author_icon: "http://flickr.com/icons/bobby.jpg"
          title: "Slack API Documentation number 2"
          title_link: "https://api.slack.com/"
          text: "{{ execution.result.stdout }}"
          fields:
            - title: "Priority"
              value: "Low"
              short: false
          image_url: "http://my-website.com/path/to/image.jpg"
          thumb_url: "http://example.com/path/to/thumb.png"
        - color: "#ffff00"
          fallback: "Required plain-text summary of the attachment number 3."
          pretext: "Optional text that appears above the attachment block number 3"
          author_name: "Bobby Tables number 3"
          author_link: "http://flickr.com/bobby/"
          author_icon: "http://flickr.com/icons/bobby.jpg"
          title: "Slack API Documentation number 3"
          title_link: "https://api.slack.com/"
          text: "Optional text that appears within the attachment number 3"
          fields:
            - title: "Priority"
              value: "Low"
              short: false
          image_url: "http://my-website.com/path/to/image.jpg"
          thumb_url: "http://example.com/path/to/thumb.png"
```

Which will actually write ```{{ execution.result.stdout }}``` and the attachments after it or you can do:

```
result:
  extra:
    slack:
      content:
          color: "#1100ff"
          fallback: "Required plain-text summary of the attachment number 2."
          pretext: "Optional text that appears above the attachment block number 2"
          author_name: "Bobby Tables number 2"
          author_link: "http://flickr.com/bobby/"
          author_icon: "http://flickr.com/icons/bobby.jpg"
          title: "Slack API Documentation number 2"
          title_link: "https://api.slack.com/"
          text: "{{ execution.result.stdout }}"
          fields:
            - title: "Priority"
              value: "Low"
              short: false
          image_url: "http://my-website.com/path/to/image.jpg"
          thumb_url: "http://example.com/path/to/thumb.png"
```

Which does exactly the same that as the current implementation of attachment. Finally, you can also combine `content` and `attachments`.

`content` is just supported to emulate the current implementation but I think it is not necessary, `attachments` should be probably good enough.

What do you think?