### PR TITLE
Fix node Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ language: node_js
 
 node_js:
   - "0.12"
+  - "4"
+  - "5"
+  - "6"
   - "iojs"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "test": "node_modules/.bin/gulp"
   },
   "engines": {
-    "node": ">= 0.10.x"
+    "node": ">= 0.12.x"
   }
 }


### PR DESCRIPTION
Playing with ChatOps, it didn't work on node.js `0.10.x`.

So it's good to state that clearly in `package.json`.