### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "url": "https://github.com/StackStorm/hubot-stackstorm/issues"
   },
   "dependencies": {
-    "lodash": "~3.8.0",
     "cli-table": "<=1.0.0",
+    "lodash": "~3.8.0",
     "rsvp": "3.0.14",
     "st2client": "^0.4.3",
     "truncate": "^1.0.4",
-    "node-uuid": "~1.4.0"
+    "uuid": "^3.0.0"
   },
   "peerDependencies": {
     "hubot": "2.x"

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -41,7 +41,7 @@ var _ = require('lodash'),
   postData = require('../lib/post_data.js'),
   CommandFactory = require('../lib/command_factory.js'),
   st2client = require('st2client'),
-  uuid = require('node-uuid')
+  uuid = require('uuid')
   ;
 
 // Setup the Environment


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.