### PR TITLE
Mattermost support

### DIFF
--- a/lib/format_data.js
+++ b/lib/format_data.js
@@ -57,6 +57,38 @@ SlackFormatter.prototype.normalizeCommand = function(command) {
 };
 
 /*
+MattermostFormatter.
+*/
+function MattermostFormatter(robot) {
+this.robot = robot;
+}
+
+MattermostFormatter.prototype.formatData = function(data) {
+if (utils.isNull(data)) {
+  return "";
+}
+// For slack we do not truncate or format the result. This is because
+// data is posted to slack as a message attachment.
+return data;
+};
+
+MattermostFormatter.prototype.formatRecepient = function(recepient) {
+return recepient;
+};
+
+MattermostFormatter.prototype.normalizeCommand = function(command) {
+// replace left double quote with regular quote
+command = command.replace(/\u201c/g, '\u0022');
+// replace right double quote with regular quote
+command = command.replace(/\u201d/g, '\u0022');
+// replace left single quote with regular apostrophe
+command = command.replace(/\u2018/g, '\u0027');
+// replace right single quote with regular apostrophe
+command = command.replace(/\u2019/g, '\u0027');
+return command;
+};
+
+/*
   HipChatFormatter.
 */
 function HipChatFormatter(robot) {
@@ -112,6 +144,8 @@ DefaultFormatter.prototype.normalizeCommand = function(command) {
 
 var formatters = {
   'slack': SlackFormatter,
+  'matteruser': MattermostFormatter,
+  'mattermost': MattermostFormatter,
   'hipchat': HipChatFormatter,
   'default': DefaultFormatter
 };

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -81,6 +81,65 @@ SlackDataPostHandler.prototype.postData = function(data) {
 };
 
 /*
+MattermostDataPostHandler.
+*/
+function MattermostDataPostHandler(robot, formatter) {
+this.robot = robot;
+this.formatter = formatter;
+}
+
+MattermostDataPostHandler.prototype.postData = function(data) {
+var recipient, attachment_color, split_message,
+    attachment, pretext = "";
+
+if (data.whisper && data.user) {
+  recipient = data.user;
+} else {
+  recipient = data.channel;
+  pretext = (data.user && !data.whisper) ? util.format('@%s: ', data.user) : "";
+}
+
+if (data.extra && data.extra.color) {
+  attachment_color = data.extra.color;
+} else {
+  attachment_color = env.ST2_MATTERMOST_SUCCESS_COLOR;
+  if (data.message.indexOf("status : failed") > -1) {
+    attachment_color = env.ST2_MATTERMOST_FAIL_COLOR;
+  }
+}
+
+split_message = utils.splitMessage(this.formatter.formatData(data.message));
+
+if (split_message.text) {
+  var content = {
+    color: attachment_color,
+    "mrkdwn_in": ["text", "pretext"],
+  };
+  if (data.extra && data.extra.mattermost) {
+    for (var attrname in data.extra.mattermost) { content[attrname] = data.extra.mattermost[attrname]; }
+  }
+  var robot = this.robot;
+  var chunks = split_message.text.match(/[\s\S]{1,7900}/g);
+  var sendChunk = function (i) {
+    content.text = chunks[i];
+    content.fallback = chunks[i];
+    attachment = {
+      room: recipient,
+      attachments: content,
+      text: i === 0 ? pretext + split_message.pretext : null
+    };
+    robot.emit('slack-attachment', attachment);
+    if (chunks.length > ++i) {
+      setTimeout(function(){ sendChunk(i); }, 300);
+    }
+  };
+  sendChunk(0);
+} else {
+  this.robot.messageRoom.call(this.robot, recipient, pretext + split_message.pretext);
+}
+};
+
+/*
   HipchatDataPostHandler.
 */
 function HipchatDataPostHandler(robot, formatter) {
@@ -191,6 +250,8 @@ DefaultFormatter.prototype.postData = function(data) {
 
 var dataPostHandlers = {
   'slack': SlackDataPostHandler,
+  'matteruser': MattermostDataPostHandler,
+  'mattermost': MattermostDataPostHandler,
   'hipchat': HipchatDataPostHandler,
   'yammer': YammerDataPostHandler,
   'default': DefaultFormatter


### PR DESCRIPTION
Hello. I have added support for Mattermost. I use [hubot-matteruser](https://github.com/loafoe/hubot-matteruser) adapter and it works well, but I think it should work with [hubot-mattermost](https://github.com/renanvicente/hubot-mattermost) adapter too.

> result:
  format: "{~} Kitten"
  extra:
    mattermost:
      image_url: "http://i.imgur.com/Gb9kAYK.jpg"
      color: "#00AA00"