### PR TITLE
Slack post data should use new chat postMessage API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+0.6.0
+-----
+* Update Slack to use new chat postMessage API from 'hubot-slack' v4
+
 0.5.1
 -----
 * Update uuid to version 3.0.0

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -32,12 +32,21 @@ function SlackDataPostHandler(robot, formatter) {
 SlackDataPostHandler.prototype.postData = function(data) {
   var recipient, attachment_color, split_message,
       attachment, pretext = "";
+  var envelope;
 
   if (data.whisper && data.user) {
     recipient = data.user;
+    envelope = {
+      "user": data.user
+    };
   } else {
     recipient = data.channel;
     pretext = (data.user && !data.whisper) ? util.format('@%s: ', data.user) : "";
+    envelope = {
+      "room": data.channel,
+      "id": data.channel,
+      "user": data.user,
+    };
   }
 
   if (data.extra && data.extra.color) {
@@ -62,21 +71,18 @@ SlackDataPostHandler.prototype.postData = function(data) {
     var robot = this.robot;
     var chunks = split_message.text.match(/[\s\S]{1,7900}/g);
     var sendChunk = function (i) {
-      content.text = chunks[i];
+      var text = i === 0 ? pretext + split_message.pretext : chunks[i];
+      content.text = text;
       content.fallback = chunks[i];
-      attachment = {
-        channel: recipient,
-        content: content,
-        text: i === 0 ? pretext + split_message.pretext : null
-      };
-      robot.emit('slack-attachment', attachment);
+      robot.adapter.client.send(envelope, {'attachments': [content]})
+
       if (chunks.length > ++i) {
         setTimeout(function(){ sendChunk(i); }, 300);
       }
     };
     sendChunk(0);
   } else {
-    this.robot.messageRoom.call(this.robot, recipient, pretext + split_message.pretext);
+    this.robot.adapter.client.send(envelope, pretext + split_message.pretext);
   }
 };
 

--- a/lib/post_data.js
+++ b/lib/post_data.js
@@ -71,10 +71,10 @@ SlackDataPostHandler.prototype.postData = function(data) {
     var robot = this.robot;
     var chunks = split_message.text.match(/[\s\S]{1,7900}/g);
     var sendChunk = function (i) {
-      var text = i === 0 ? pretext + split_message.pretext : chunks[i];
-      content.text = text;
+      content.pretext = i === 0 ? pretext + split_message.pretext : null;
+      content.text = chunks[i];
       content.fallback = chunks[i];
-      robot.adapter.client.send(envelope, {'attachments': [content]})
+      robot.adapter.client.send(envelope, {'attachments': [content]});
 
       if (chunks.length > ++i) {
         setTimeout(function(){ sendChunk(i); }, 300);
@@ -237,14 +237,14 @@ SparkDataPostHandler.prototype.postData = function(data) {
       text = "";
 
   if (data.whisper && data.user) {
-    recipient = { user: data.user }
+    recipient = { user: data.user };
   } else {
-    recipient = { channel: data.channel }
+    recipient = { channel: data.channel };
     text = (data.user && !data.whisper) ? util.format('%s: ', data.user) : "";
   }
 
   recipient = this.formatter.formatRecepient(recipient);
-  recipient.extra = data.extra
+  recipient.extra = data.extra;
   text += this.formatter.formatData(data.message);
 
   // Ignore the delimiter in the default formatter and just concat parts.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-stackstorm",
   "description": "A hubot plugin for integrating with StackStorm event-driven infrastructure automation platform.",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "author": "StackStorm, Inc. <info@stackstorm.com>",
   "license": "Apache-2.0",
   "keywords": [

--- a/tests/dummy-adapters.js
+++ b/tests/dummy-adapters.js
@@ -29,7 +29,6 @@ MockSlackClient.prototype.send = function(envelope, message) {
 function MockSlackAdapter(logger) {
     this.logger = logger;
     this.client = new MockSlackClient(logger);
-    console.log(this.client.send);
 }
 
 module.exports =  MockSlackAdapter;

--- a/tests/dummy-adapters.js
+++ b/tests/dummy-adapters.js
@@ -15,49 +15,21 @@
 limitations under the License.
 */
 
+
 "use strict";
 
-var Log = require('log');
-
-function Logger(enabled) {
-  this.enabled = enabled;
-  this.log = new Log('debug');
-
-  this.error = function(msg) {
-    if (!this.enabled) {
-      return;
-    }
-    this.log.error(msg);
-  };
-
-  this.warning = function(msg) {
-    if (!this.enabled) {
-      return;
-    }
-    this.log.warning(msg);
-  };
-
-  this.info = function(msg) {
-    if (!this.enabled) {
-      return;
-    }
-    this.log.info(msg);
-  };
-
-  this.debug = function(msg) {
-    if (!this.enabled) {
-      return;
-    }
-    this.log.debug(msg);
-  };
-
+function MockSlackClient(logger) {
+    this.logger = logger;
 }
 
-function Robot(name, adapter, enable_logging) {
-  this.logger = new Logger(enable_logging);
-  this.name = name;
-  this.commands = [];
-  this.adapter = adapter;
+MockSlackClient.prototype.send = function(envelope, message) {
+    this.logger.info('Sending ' + JSON.stringify(message) + ' to ' + JSON.stringify(envelope));
+};
+
+function MockSlackAdapter(logger) {
+    this.logger = logger;
+    this.client = new MockSlackClient(logger);
+    console.log(this.client.send);
 }
 
-module.exports = Robot;
+module.exports =  MockSlackAdapter;

--- a/tests/test-formatdata.js
+++ b/tests/test-formatdata.js
@@ -121,7 +121,7 @@ describe('HipChatFormatter', function() {
 
 describe('DefaultFormatter', function() {
   var adapterName = 'unknown';
-  var robot = new DummyRobot('dummy', false);
+  var robot = new DummyRobot('dummy', null, false);
 
   it('should create a snippet for non-empty', function() {
     var formatter = formatData.getFormatter(adapterName, robot);


### PR DESCRIPTION
Based on https://github.com/slackapi/hubot-slack/pull/355/files#diff-04c6e90faac2675aa89e2176d2eec7d8R86 and https://api.slack.com/methods/chat.postMessage#formatting


Also closes #121 