### PR TITLE
Feature/add error message cmd not found

### DIFF
--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -321,6 +321,9 @@ module.exports = function(robot) {
     result = command_factory.getMatchingCommand(command);
 
     if (!result) {
+      if (command.startsWith("help")) {
+          return;
+      }
       var message = util.format(_.sample(ERROR_MESSAGES), "Command not found: " + command);
       return msg.send(message);
     }

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -321,7 +321,7 @@ module.exports = function(robot) {
     result = command_factory.getMatchingCommand(command);
 
     if (!result) {
-      var message = util.format(_.sample(ERROR_MESSAGES), "Command not found");
+      var message = util.format(_.sample(ERROR_MESSAGES), "Command not found: " + command);
       return msg.send(message);
     }
 

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -321,8 +321,8 @@ module.exports = function(robot) {
     result = command_factory.getMatchingCommand(command);
 
     if (!result) {
-      // No command found
-      return;
+      var message = util.format(_.sample(ERROR_MESSAGES), "Command not found");
+      return msg.send(message);
     }
 
     command_name = result[0];


### PR DESCRIPTION
If someone gives the chatbot a command that is not registered, provide an error message back to the user.