### PR TITLE
Add ability to specify stream URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - "0.12"
   - "4"
   - "5"
   - "6"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,29 +1,32 @@
-0.8.0
------
-* Add support for specifying Stream URL
-* Update st2client to 1.1.1
-* Drop Node.js 0.12 support
+Changelog
+=========
+
+in development
+--------------
+* Add support for specifying Stream URL (new feature)
+* Update st2client to 1.1.1 (improvement)
+* Drop Node.js 0.12 support (change)
 
 0.7.0
 -----
-* Add RocketChat support
+* Add RocketChat support (new feature)
 
 0.6.0
 -----
-* Update Slack to use new chat postMessage API from 'hubot-slack' v4
+* Update Slack to use new chat postMessage API from 'hubot-slack' v4 (new feature)
 
 0.5.1
 -----
-* Update uuid to version 3.0.0
-* Add support for sending file attachments via the extra dict to the spark adapter
+* Update uuid to version 3.0.0 (improvement)
+* Add support for sending file attachments via the extra dict to the spark adapter (improvement)
 
 0.5.0
 -----
-* Mattermost support
+* Mattermost support (new feature)
 
 0.3.0
 -----
-* Switched to st2client.js
+* Switched to st2client.js (new feature)
 * Chatops announcements (new feature)
 * Custom formatting for results (new feature)
 * Disabling ack and results for specific aliases (new feature)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+0.8.0
+-----
+* Add support for specifying Stream URL
+* Update st2client to 1.1.1
+* Drop Node.js 0.12 support
+
 0.7.0
 -----
 * Add RocketChat support

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ specified when running hubot:
 * `ST2_AUTH_USERNAME` - API credentials - username (optional).
 * `ST2_AUTH_PASSWORD` - API credentials - password (optional).
 * `ST2_AUTH_URL` - URL to the StackStorm Auth API (optional).
+* `ST2_STREAM_URL` - URL to the StackStorm Stream API (optional).
 * `ST2_COMMANDS_RELOAD_INTERVAL` - How often the list of available commands
   should be reloaded. Defaults to every 120 seconds (optional).
 * `ST2_MAX_MESSAGE_LENGTH` - Message truncation to preserve chat context. Default is 500 characters of length. 0 means no limit (optional).

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cli-table": "<=1.0.0",
     "lodash": "~3.8.0",
     "rsvp": "3.0.14",
-    "st2client": "^0.4.3",
+    "st2client": "^1.1.1",
     "truncate": "^1.0.4",
     "uuid": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "test": "node_modules/.bin/gulp"
   },
   "engines": {
-    "node": ">= 0.12.x"
+    "node": ">=4.0.0"
   }
 }

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -66,6 +66,9 @@ env.ST2_SLACK_FAIL_COLOR = env.ST2_SLACK_FAIL_COLOR || 'danger';
 // Optional, if not provided, we infer it from the API URL
 env.ST2_AUTH_URL = env.ST2_AUTH_URL || null;
 
+// Optional, if not provided, we infer it from the API URL
+env.ST2_STREAM_URL = env.ST2_STREAM_URL || null;
+
 // Command reload interval in seconds
 env.ST2_COMMANDS_RELOAD_INTERVAL = parseInt(env.ST2_COMMANDS_RELOAD_INTERVAL || 120, 10);
 
@@ -110,6 +113,16 @@ module.exports = function(robot) {
     prefix: url.path,
     rejectUnauthorized: false
   };
+
+  if (env.ST2_STREAM_URL) {
+    var stream_url = utils.parseUrl(env.ST2_STREAM_URL);
+    opts.stream = {
+      protocol: stream_url.protocol,
+      host: stream_url.hostname,
+      port: stream_url.port,
+      prefix: stream_url.path
+    };
+  }
 
   var api = st2client(opts);
 


### PR DESCRIPTION
Solves #143 

- `st2client.js` needs to be updated since 0.4.3 does not support specifying stream url
- Use `utils.parseUrl()` just like `ST2_AUTH_URL` do, even the same logic is implemented in `st2client.js` ([here](https://github.com/StackStorm/st2client.js/blob/master/index.js#L50) and [here](https://github.com/StackStorm/st2client.js/blob/master/index.js#L63))
    - We can just pass single string to `opts.auth` or `opts.stream` and let `st2client.js` handle URL parsing, but that is out of the scope here. If we want to do that, we should do it in separate PR.
