### PR TITLE
Enable Hubot hear" listeners in StackStorm alias configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+
+*.sublime-project
+*.sublime-workspace
+
 node_modules/
 
 npm-debug.log

--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -19,6 +19,7 @@ limitations under the License.
 
 var _ = require('lodash');
 var utils = require('./utils.js');
+var XRegExp = require('xregexp');
 
 
 /**
@@ -42,7 +43,7 @@ function CommandFactory(robot) {
 }
 
 CommandFactory.prototype.getRegexForFormatString = function(format) {
-  var extra_params, regex_str, regex;
+  var extra_params, regex, regex_str = format;
 
   // Note: We replace format parameters with ([\s\S]+?) and allow arbitrary
   // number of key=value pairs at the end of the string
@@ -50,11 +51,50 @@ CommandFactory.prototype.getRegexForFormatString = function(format) {
   // be skipped.
   // Note that we use "[\s\S]" instead of "." to allow multi-line values
   // and multi-line commands in general.
+
+  // Optional multiple key=value pairs
+  // ( attr_name="value"|'something'|({something})|something )*
   extra_params = '(\\s+(\\S+)\\s*=("([\\s\\S]*?)"|\'([\\s\\S]*?)\'|({[\\s\\S]*?})|(\\S+))\\s*)*';
-  regex_str = format.replace(/(\s*){{\s*\S+\s*=\s*(?:({.+?}|.+?))\s*}}(\s*)/g, '\\s*($1([\\s\\S]+?)$3)?\\s*');
-  regex_str = regex_str.replace(/\s*{{.+?}}\s*/g, '\\s*([\\s\\S]+?)\\s*');
-  regex = new RegExp('^\\s*' + regex_str + extra_params + '\\s*$', 'i');
-  return regex;
+
+  // From https://docs.stackstorm.com/chatops/aliases.html
+  // Possible inputs:
+  // Basic: "run {{cmd}} on {{hosts}}" -> /run (?<cmd>\S+) on (?<hosts>\S+)/
+  // With default: "run {{cmd}} on {{hosts=localhost}}" -> /run (?<cmd>\S+) on (?<hosts>\S+)/
+  // With JSON default: "run {{thing={'key': 'value'}}}" -> /run (?<thing>[^\s=]+).*?/
+  // Regular expressions: "(run|execute) {{cmd}}( on {{hosts=localhost}})?[!.]?"
+  // Key-value parameters: "run {{cmd}} on {{hosts}} {{key1}}={{value1}} {{key2}}={{value2}}"
+  //
+  // This function is intentionally written to be as stupid as possible. We
+  // avoid attempting parsing regex strings with regexes, as down that path
+  // lies madness.
+  //
+  // If you pass in a format string, we convert that to a regex for you, with
+  // full named capture groups and everything.
+  // But if you pass in a fully-formed regex, we completely leave that alone.
+  // Write your aliases accordingly!
+
+  if (regex_str.indexOf("{{") !== -1 && regex_str.indexOf("}}") !== -1) {
+    // {{ option=default_value }} -> (([\s\S]+?))?  // Why wrap the whole thing in an optional group?
+    regex_str = regex_str.replace(/(\s*){{\s*([\w_]+)\s*=\s*(?:({.+?}|.+?))\s*}}(\s*)/g, '\\s*($1$2(?<$2>[\\s\\S]+?)$4)?\\s*');
+
+    // {{ option }} -> ([\s\S]+?)
+    // Grab the whitespace on either side so regexes can specify whether or not the whitespace is optional
+    // regex_str = regex_str.replace(/(\s*){{\s*([\w_]+).*?\s*}}(\s*)/g, '$1(?<$2>[\\s\\S]+?)$3');
+    var parameter_re = new XRegExp('(?<before_ws>\\s*){{\\s*(?<var>[\\w_]+).*?\\s*}}(?<after_ws>\\s*)', 'g');
+    regex_str = XRegExp.replace(regex_str, parameter_re, '${before_ws}(?<${var}>[\\s\\S]+?)${after_ws}');
+
+    // Only anchor if we aren't anchored already
+    if (regex_str.charAt(0) !== '^') {
+      regex_str = '^\s*' + regex_str;
+    }
+
+    // Only allow extra params if we aren't anchored
+    if (regex_str.charAt(regex_str.length-1) !== '$') {
+      regex_str = regex_str + extra_params + '\\s*$';
+    }
+  }
+
+  return new XRegExp(regex_str, 'i');
 };
 
 CommandFactory.prototype.addCommand = function(command, name, format, action_alias, flag) {
@@ -106,24 +146,51 @@ CommandFactory.prototype.removeCommands = function() {
 };
 
 CommandFactory.prototype.getMatchingCommand = function(command) {
+  var results = this.getMatchingCommands(command);
+
+  // Preserve backwards compatibility
+  if (!results.length) {
+    return null;
+  }
+
+  return results;
+};
+
+CommandFactory.prototype.getMatchingCommands = function(command) {
+  if (RegExp.prototype.flags === undefined) {
+    Object.defineProperty(RegExp.prototype, 'flags', {
+      configurable: true,
+      get: function() {
+        return this.toString().match(/[gimuy]*$/)[0];
+      }
+    });
+  }
+
   var result, common_prefix, command_name, command_arguments, format_strings,
-      i, format_string, regex, action_alias;
+      i, m, format_string, regex, action_alias,
+      rtn_list = [];
 
   // 1. Try to use regex search - this works for commands with a format string
   format_strings = Object.keys(this.st2_commands_regex_map);
 
-  for (i = 0; i < format_strings.length; i++) {
+  for (i = format_strings.length-1; i >= 0; i--) {
     format_string = format_strings[i];
     regex = this.st2_commands_regex_map[format_string];
-    if (regex.test(command)) {
+
+    // Build a regex that checks globally
+    var new_regex_flags = regex.flags;
+    new_regex_flags = new_regex_flags.replace(/g?/, 'g');
+    var new_regex = new RegExp(regex.source, new_regex_flags);
+
+    while ((m = new_regex.exec(command)) !== null) {
       action_alias = this.st2_commands_format_map[format_string];
       command_name = action_alias.name;
 
-      return [command_name, format_string, action_alias];
+      rtn_list.push([command_name, format_string, action_alias, m[0]]);
     }
   }
 
-  return null;
+  return rtn_list;
 };
 
 module.exports = CommandFactory;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "rsvp": "3.0.14",
     "st2client": "^0.4.3",
     "truncate": "^1.0.4",
-    "uuid": "^3.0.0"
+    "uuid": "^3.0.0",
+    "xregexp": "^3.2.0"
   },
   "peerDependencies": {
     "hubot": "2.x"


### PR DESCRIPTION
# Overview #

This PR uses Hubot's `hear()` function to listen in on channels and match against regexes dynamically loaded from StackStorm.

## Examples ##

#### An action alias that can match multiple times in a message ####

```yaml
---
name: "jira_get_issue"
pack: "jira"
action_ref: "jira.get_issue"
description: "Get a blurb from a Jira issue."
formats:
  - display: "jira issue <issue key>"
    representation:
      - "jira i(?:ssue)? (?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)"
  - display: "<issue key>"
    representation:
      - (?:^|\b)(?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)(?:\b|$)
    regex_flags: g
```

This action alias allows hubot to match a Jira issue key multiple times in one message, so the following Slack message would dispatch multiple times to StackStorm:

> Hey, I started working on SERVICEDESK-1234, but I got blocked by INFRASTRUCTURE-4321. I switch over to working on SERVICEDESK-1235 instead.

Specifically, with this change, Hubot would dispatch three different times to StackStorm:

1. Once for the issue key `SERVICEDESK-1234`
2. Once for the issue key `INFRASTRUCTURE-4321`
3. Once for the issue key `SERVICEDESK-1235`

The `regex_flags` key is exposed to hubot-stackstorm through StackStorm's API, so H-S can compile the regular expression with the appropriate flags.

## Extensibility ##

Our current actions simply respond with a blob of the the issue description in Slack, saving our users a round trip to Jira (which could itself include a login) to read the issue. However, the exact action is not limited to this.

I changed the regex engine from Node.js' default regex engine to the XRegExp engine. I did this because it's compatible with both Python group captures so only one regex format needs to be written.

# Motivation #

This PR sets the stage for some of our changes to the [StackStorm Jira pack](https://github.com/StackStorm-Exchange/stackstorm-jira). We are working on upstreaming those changes as well, once these changes are put into place.