### PR TITLE
Hubot hear and multiple dispatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 *.sublime-project
 *.sublime-workspace
 
-node_modules/
-
+.coverrun
 npm-debug.log
+
+.coverdata/
+coverage/
+debug/
+node_modules/
+reports/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+
+*.sublime-project
+*.sublime-workspace
+
 node_modules/
 
 npm-debug.log

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,8 @@ limitations under the License.
 var gulp = require('gulp'),
   jshint = require('gulp-jshint'),
   plumber = require('gulp-plumber'),
-  mocha = require('gulp-mocha');
+  mocha = require('gulp-mocha'),
+  cover = require('gulp-coverage');
 
 gulp.task('lint', function () {
   return gulp.src(['scripts/**/*.js', 'lib/**/*.js', 'tests/**/*.js'])
@@ -33,9 +34,16 @@ gulp.task('test', function () {
   return gulp.src('tests/**/*.js', {
       read: false
     })
+    .pipe(cover.instrument({
+      pattern: ['scripts/**/*.js', 'lib/**/*.js', 'tests/**/*.js'],
+      debugDirectory: 'debug'
+    }))
     .pipe(mocha({
       reporter: 'spec'
-    }));
+    }))
+    .pipe(cover.gather())
+    .pipe(cover.format())
+    .pipe(gulp.dest('reports'));
 });
 
 gulp.task('default', ['lint', 'test']);

--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -24,6 +24,23 @@ var utils = require('./utils.js');
 var XRegExp = require('xregexp');
 
 
+// Polyfill from:
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes
+if (!String.prototype.includes) {
+  String.prototype.includes = function(search, start) {
+    if (typeof start !== 'number') {
+      start = 0;
+    }
+
+    if (start + search.length > this.length) {
+      return false;
+    } else {
+      return this.indexOf(search, start) !== -1;
+    }
+  };
+}
+
+
 /**
  * Manage command for stackstorm, storing them in robot and providing
  * lookups given command literals.

--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -19,6 +19,7 @@ limitations under the License.
 
 var _ = require('lodash');
 var utils = require('./utils.js');
+var XRegExp = require('xregexp');
 
 
 /**
@@ -39,10 +40,13 @@ function CommandFactory(robot) {
 
   // Maps command format to a compiled regex for that format
   this.st2_commands_regex_map = {};
+
+  // Maps command format to a compiled regex for that format
+  this.st2_commands_global_regex_map = {};
 }
 
-CommandFactory.prototype.getRegexForFormatString = function(format) {
-  var extra_params, regex_str, regex;
+CommandFactory.prototype.getRegexForFormatString = function(format, flags) {
+  var extra_params, regex, regex_str = format;
 
   // Note: We replace format parameters with ([\s\S]+?) and allow arbitrary
   // number of key=value pairs at the end of the string
@@ -50,15 +54,58 @@ CommandFactory.prototype.getRegexForFormatString = function(format) {
   // be skipped.
   // Note that we use "[\s\S]" instead of "." to allow multi-line values
   // and multi-line commands in general.
+
+  // Optional multiple key=value pairs
+  // ( attr_name="value"|'something'|({something})|something )*
   extra_params = '(\\s+(\\S+)\\s*=("([\\s\\S]*?)"|\'([\\s\\S]*?)\'|({[\\s\\S]*?})|(\\S+))\\s*)*';
-  regex_str = format.replace(/(\s*){{\s*\S+\s*=\s*(?:({.+?}|.+?))\s*}}(\s*)/g, '\\s*($1([\\s\\S]+?)$3)?\\s*');
-  regex_str = regex_str.replace(/\s*{{.+?}}\s*/g, '\\s*([\\s\\S]+?)\\s*');
-  regex = new RegExp('^\\s*' + regex_str + extra_params + '\\s*$', 'i');
-  return regex;
+
+  // From https://docs.stackstorm.com/chatops/aliases.html
+  // Possible inputs:
+  // Basic: "run {{cmd}} on {{hosts}}" -> /run (?<cmd>\S+) on (?<hosts>\S+)/
+  // With default: "run {{cmd}} on {{hosts=localhost}}" -> /run (?<cmd>\S+) on (?<hosts>\S+)/
+  // With JSON default: "run {{thing={'key': 'value'}}}" -> /run (?<thing>[^\s=]+).*?/
+  // Regular expressions: "(run|execute) {{cmd}}( on {{hosts=localhost}})?[!.]?"
+  // Key-value parameters: "run {{cmd}} on {{hosts}} {{key1}}={{value1}} {{key2}}={{value2}}"
+  //
+  // This function is intentionally written to be as stupid as possible. We
+  // avoid attempting parsing regex strings with regexes, as down that path
+  // lies madness.
+  //
+  // If you pass in a format string, we convert that to a regex for you, with
+  // full named capture groups and everything.
+  // But if you pass in a fully-formed regex, we completely leave that alone.
+  // Write your aliases accordingly!
+
+  if (regex_str.indexOf("{{") !== -1 && regex_str.indexOf("}}") !== -1) {
+    // {{ option=default_value }} -> (([\s\S]+?))?  // Why wrap the whole thing in an optional group?
+    regex_str = regex_str.replace(/(\s*){{\s*(\S+)\s*=\s*(?:({.+?}|.+?))\s*}}(\s*)/g, '\\s*($1(?<$2>[\\s\\S]+?)$4)?\\s*');
+
+    // {{ option }} -> ([\s\S]+?)
+    // Grab the whitespace on either side so regexes can specify whether or not the whitespace is optional
+    // regex_str = regex_str.replace(/(\s*){{\s*([\w_]+).*?\s*}}(\s*)/g, '$1(?<$2>[\\s\\S]+?)$3');
+    var parameter_re = new XRegExp('(?<before_ws>\\s*){{\\s*(?<var>[\\w_]+).*?\\s*}}(?<after_ws>\\s*)', 'g');
+    regex_str = XRegExp.replace(regex_str, parameter_re, '${before_ws}(?<${var}>[\\s\\S]+?)${after_ws}');
+
+    // Only anchor if we aren't anchored already
+    if (regex_str.charAt(0) !== '^') {
+      regex_str = '^\s*' + regex_str;
+    }
+
+    // Only allow extra params if we aren't anchored
+    if (regex_str.charAt(regex_str.length-1) !== '$') {
+      regex_str = regex_str + extra_params + '\\s*$';
+    }
+  }
+
+  // Pass the flags in, guaranteeing that they include an 'i'
+  return new XRegExp(regex_str, flags ? (flags.includes('i') ? flags : flags + 'i') : 'i');
 };
 
 CommandFactory.prototype.addCommand = function(command, name, format, action_alias, flag) {
-  var compiled_template, context, command_string, regex;
+  var compiled_template, context, command_string, regex,
+      representation = (!flag || (flag & utils.REPRESENTATION)),
+      display = (!flag || (flag & utils.DISPLAY)),
+      _global = (!!flag && (flag & utils.G));  /* regex global flag */
 
   if (!format) {
     this.robot.logger.error('Skipped empty command.');
@@ -73,14 +120,19 @@ CommandFactory.prototype.addCommand = function(command, name, format, action_ali
   compiled_template = _.template('hubot ${command}');
   command_string = compiled_template(context);
 
-  if (!flag || flag === utils.REPRESENTATION) {
+  if (representation) {
     this.st2_hubot_commands.push(command_string);
     this.st2_commands_name_map[name] = action_alias;
     this.st2_commands_format_map[format] = action_alias;
-    regex = this.getRegexForFormatString(format);
-    this.st2_commands_regex_map[format] = regex;
+    regex = this.getRegexForFormatString(format, (flag & utils.G) ? 'g' : '');
+
+    if (_global) {
+      this.st2_commands_global_regex_map[format] = regex;
+    } else {
+      this.st2_commands_regex_map[format] = regex;
+    }
   }
-  if ((!flag || flag === utils.DISPLAY) && this.robot.commands.indexOf(command_string) === -1) {
+  if (display && this.robot.commands.indexOf(command_string) === -1) {
     this.robot.commands.push(command_string);
   }
 
@@ -103,6 +155,7 @@ CommandFactory.prototype.removeCommands = function() {
   this.st2_commands_name_map = {};
   this.st2_commands_format_map = {};
   this.st2_commands_regex_map = {};
+  this.st2_commands_global_regex_map = {};
 };
 
 CommandFactory.prototype.getMatchingCommand = function(command) {
@@ -120,6 +173,42 @@ CommandFactory.prototype.getMatchingCommand = function(command) {
       command_name = action_alias.name;
 
       return [command_name, format_string, action_alias];
+    }
+  }
+
+  return null;
+};
+
+CommandFactory.prototype.getMatchingCommands = function(command) {
+  if (RegExp.prototype.flags === undefined) {
+    Object.defineProperty(RegExp.prototype, 'flags', {
+      configurable: true,
+      get: function() {
+        return this.toString().match(/[gimuy]*$/)[0];
+      }
+    });
+  }
+
+  var result, common_prefix, command_name, command_arguments, format_strings,
+      i, m, format_string, regex, action_alias,
+      rtn_list = [];
+
+  // 1. Try to use regex search - this works for commands with a format string
+  format_strings = Object.keys(this.st2_commands_global_regex_map);
+
+  for (i = 0; i < format_strings.length; i++) {
+    format_string = format_strings[i];
+    regex = this.st2_commands_global_regex_map[format_string];
+
+    while ((m = regex.exec(command)) !== null) {
+      action_alias = this.st2_commands_format_map[format_string];
+      command_name = action_alias.name;
+
+      rtn_list.push([command_name, format_string, action_alias, m[0]]);
+    }
+
+    if (rtn_list.length > 0) {
+      return rtn_list;
     }
   }
 

--- a/lib/command_factory.js
+++ b/lib/command_factory.js
@@ -14,6 +14,8 @@
  See the License for the specific language governing permissions and
 limitations under the License.
 */
+/* globals module, require */
+/* jshint globalstrict:true */
 
 "use strict";
 

--- a/lib/format_data.js
+++ b/lib/format_data.js
@@ -45,6 +45,10 @@ SlackFormatter.prototype.formatRecepient = function(recepient) {
 };
 
 SlackFormatter.prototype.normalizeCommand = function(command) {
+  if (!command) {
+    this.robot.logger.warning("Bad regex passed to normalizeCommand: " + command);
+  }
+
   // replace left double quote with regular quote
   command = command.replace(/\u201c/g, '\u0022');
   // replace right double quote with regular quote

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,6 +27,7 @@ var CLI_EXECUTION_GET_CMD = 'st2 execution get %s';
 var PRETEXT_DELIMITER = '{~}';
 var DISPLAY = 1;
 var REPRESENTATION = 2;
+var G = 4;  // Global regex
 
 
 function isNull(value) {
@@ -128,3 +129,4 @@ exports.enable2FA = enable2FA;
 exports.normalizeAddressee = normalizeAddressee;
 exports.DISPLAY = DISPLAY;
 exports.REPRESENTATION = REPRESENTATION;
+exports.G = G;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "rsvp": "3.0.14",
     "st2client": "^0.4.3",
     "truncate": "^1.0.4",
-    "uuid": "^3.0.0"
+    "uuid": "^3.0.0",
+    "xregexp": "^3.2.0"
   },
   "peerDependencies": {
     "hubot": "2.x"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "cli-table": "<=1.0.0",
+    "gulp-coverage": "^0.3.38",
     "lodash": "~3.8.0",
     "rsvp": "3.0.14",
     "st2client": "^0.4.3",

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -243,6 +243,9 @@ module.exports = function(robot) {
                    * match once.
                    */
                   executeCommand(msg, result[0], result[1], command, result[2]);
+
+                  msg.finish();
+
                 } else {
                   robot.logger.debug("No commands match '" + command + "', searching global commands");
 
@@ -264,6 +267,9 @@ module.exports = function(robot) {
                        */
                       executeCommand(msg, result[0], result[1], result[3], result[2]);
                     });
+
+                    msg.finish();
+
                   } else {
                     robot.logger.debug("No commands matched '" + command + "'");
                     return;

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -184,7 +184,7 @@ module.exports = function(robot) {
   var postDataHandler = postData.getDataPostHandler(robot.adapterName, robot, formatter);
 
   var loadCommands = function() {
-    robot.logger.info('Loading commands....');
+    robot.logger.info('[loadCommands] Loading commands....');
 
     api.actionAlias.list()
       .then(function (aliases) {
@@ -232,7 +232,7 @@ module.exports = function(robot) {
                 result = command_factory.getMatchingCommand(command);
 
                 if (result) {
-                  robot.logger.debug("Executing command from: " + result);
+                  robot.logger.debug("[hear] Executing command from: " + result);
                   /*
                    * command_name = result[0]
                    * format_string = result[1]
@@ -247,12 +247,12 @@ module.exports = function(robot) {
                   msg.finish();
 
                 } else {
-                  robot.logger.debug("No commands match '" + command + "', searching global commands");
+                  robot.logger.debug("[hear] No commands match '" + command + "', searching global commands");
 
                   results = command_factory.getMatchingCommands(command);
                   if (results) {
                     _.each(results, function (result) {
-                      robot.logger.debug("Executing command from: " + result);
+                      robot.logger.debug("[hear] Executing command from: " + result);
                       /*
                        * command_name = result[0]
                        * format_string = result[1]
@@ -271,7 +271,7 @@ module.exports = function(robot) {
                     msg.finish();
 
                   } else {
-                    robot.logger.debug("No commands matched '" + command + "'");
+                    robot.logger.debug("[hear] No commands matched '" + command + "'");
                     return;
                   }
                 }
@@ -280,10 +280,10 @@ module.exports = function(robot) {
           });
         });
 
-        robot.logger.info(command_factory.st2_hubot_commands.length + ' commands are loaded');
+        robot.logger.info('[loadCommands] ' + command_factory.st2_hubot_commands.length + ' commands are loaded');
       })
       .catch(function (err) {
-        var error_msg = 'Failed to retrieve commands from "%s": %s';
+        var error_msg = '[loadCommands] Failed to retrieve commands from "%s": %s';
         robot.logger.error(util.format(error_msg, env.ST2_API, err.message));
       });
   };

--- a/tests/fixtures/aliases.json
+++ b/tests/fixtures/aliases.json
@@ -35,4 +35,18 @@
       "twofactor": true
     }
   }
+}, {
+  "name": "regex2",
+  "description": "alias with regex format",
+  "formats": [
+    "regex fmt2 (?P<param1>[A-Z][A-Z0-9]+-[0-9]+) trailing words"
+  ],
+  "regex_flags": "g"
+}, {
+  "name": "regex",
+  "description": "alias with regex format",
+  "formats": [
+    "regex fmt1 (?P<param1>[A-Z][A-Z0-9]+-[0-9]+) trailing words"
+  ],
+  "regex_flags": "g"
 }]

--- a/tests/test-command-factory.js
+++ b/tests/test-command-factory.js
@@ -32,6 +32,18 @@ var ALIAS_FIXTURES = fs.readFileSync('tests/fixtures/aliases.json');
 ALIAS_FIXTURES = JSON.parse(ALIAS_FIXTURES);
 
 
+// Polyfill from:
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/flags
+if (RegExp.prototype.flags === undefined) {
+  Object.defineProperty(RegExp.prototype, 'flags', {
+    configurable: true,
+    get: function() {
+      return this.toString().match(/[gimuy]*$/)[0];
+    }
+  });
+}
+
+
 function getCleanCommandFactory() {
   var robot = new Robot(false);
   return new CommandFactory(robot);
@@ -140,7 +152,7 @@ describe('command factory', function() {
     expect(rgx.flags).to.includes('i');
   });
 
-  it('should add keep existing regex flags', function () {
+  it('should add \'i\' and keep existing regex flags', function () {
     var command_factory, rgx;
 
     command_factory = getCleanCommandFactory();

--- a/tests/test-command-factory.js
+++ b/tests/test-command-factory.js
@@ -25,7 +25,8 @@ var fs = require('fs'),
   expect = chai.expect,
   CommandFactory = require('../lib/command_factory.js'),
   Robot = require('./dummy-robot.js'),
-  formatCommand = require('../lib/format_command.js');
+  formatCommand = require('../lib/format_command.js'),
+  utils = require('../lib/utils.js');
 
 var ALIAS_FIXTURES = fs.readFileSync('tests/fixtures/aliases.json');
 ALIAS_FIXTURES = JSON.parse(ALIAS_FIXTURES);
@@ -50,6 +51,40 @@ describe('command factory', function() {
       alias);
 
     expect(command_factory.robot.commands).to.have.length(1);
+  });
+
+  it('should not have any commands with null formats', function() {
+    var command_factory, alias;
+
+    command_factory = getCleanCommandFactory();
+    alias = ALIAS_FIXTURES[0];
+
+    command_factory.addCommand(
+      formatCommand(null, alias.name, alias.formats[0], alias.description),
+      alias.name,
+      null,
+      alias);
+
+    expect(command_factory.robot.commands).to.have.length(0);
+  });
+
+  it('should add and then remove all commands from robot', function() {
+    var command_factory, alias;
+
+    command_factory = getCleanCommandFactory();
+    alias = ALIAS_FIXTURES[0];
+
+    command_factory.addCommand(
+      formatCommand(null, alias.name, alias.formats[0], alias.description),
+      alias.name,
+      alias.formats[0],
+      alias);
+
+    expect(command_factory.robot.commands).to.have.length(1);
+
+    command_factory.removeCommands();
+
+    expect(command_factory.robot.commands).to.have.length(0);
   });
 
   it('should add multiple commands to robot', function() {
@@ -94,6 +129,34 @@ describe('command factory', function() {
     match = command_factory.getMatchingCommand('alias1 fmt1 value1 breaking words');
     expect(match[0]).to.equal('alias1');
 
+  });
+
+  it('should add \'i\' to regex flags', function () {
+    var command_factory, rgx;
+
+    command_factory = getCleanCommandFactory();
+
+    rgx = command_factory.getRegexForFormatString('asdf');
+    expect(rgx.flags).to.includes('i');
+  });
+
+  it('should add keep existing regex flags', function () {
+    var command_factory, rgx;
+
+    command_factory = getCleanCommandFactory();
+
+    rgx = command_factory.getRegexForFormatString('asdf', 'g');
+    expect(rgx.flags).to.includes('g');
+    expect(rgx.flags).to.includes('i');
+  });
+
+  it('should not duplicate \'i\' flags', function () {
+    var command_factory, rgx;
+
+    command_factory = getCleanCommandFactory();
+
+    rgx = command_factory.getRegexForFormatString('asdf', 'i');
+    expect(rgx.flags).to.includes('i');
   });
 
   it('should match command literals with blank spaces in values', function() {
@@ -169,4 +232,39 @@ describe('command factory', function() {
 
   });
 
+  it('should match multiple times if regex_flags contains \'g\'', function() {
+    var alias, command_factory, matches;
+
+    command_factory = getCleanCommandFactory();
+    alias = ALIAS_FIXTURES[5];
+
+    command_factory.addCommand(
+      formatCommand(null, alias.name, alias.formats[0], alias.description),
+      alias.name,
+      alias.formats[0],
+      alias,
+      utils.REPRESENTATION | utils.G);
+
+    alias = ALIAS_FIXTURES[6];
+
+    command_factory.addCommand(
+      formatCommand(null, alias.name, alias.formats[0], alias.description),
+      alias.name,
+      alias.formats[0],
+      alias,
+      utils.REPRESENTATION | utils.G);
+
+    matches = command_factory.getMatchingCommands('regex fmt1 ASDF-1234 trailing words regex fmt1 FDSA-4321 trailing words');
+    expect(matches).to.have.length(2);
+    expect(matches[0][3]).to.equal('regex fmt1 ASDF-1234 trailing words');
+    expect(matches[1][3]).to.equal('regex fmt1 FDSA-4321 trailing words');
+  });
+
+  it('should match nothing if not global regexes are loaded', function() {
+    var alias, command_factory, matches;
+
+    command_factory = getCleanCommandFactory();
+    matches = command_factory.getMatchingCommands('regex fmt1 ASDF-1234 trailing words regex fmt1 FDSA-4321 trailing words');
+    expect(matches).to.equal(null);
+  });
 });


### PR DESCRIPTION
# Overview #

This PR uses Hubot's `hear()` function to listen in on channels and match against regexes dynamically loaded from StackStorm.

# Example #

#### An action alias that can match multiple times in a message ####

```yaml
---
name: "jira_get_issue"
pack: "jira"
action_ref: "jira.get_issue"
description: "Get a blurb from a Jira issue."
formats:
  - display: "jira issue <issue key>"
    representation:
      - "jira i(?:ssue)? (?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)"
  - display: "<issue key>"
    representation:
      - (?:^|\b)(?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)(?:\b|$)
    # Pass "global" flag to XRegExp so regex can match multiple times per message
    regex_flags: g
```

This action alias allows hubot to match a Jira issue key multiple times in one message, so the following Slack message would dispatch multiple times to StackStorm:

> Hey, I started working on SERVICEDESK-1234, but I got blocked by INFRASTRUCTURE-4321. I'm switching over to working on SERVICEDESK-1235 instead.

Specifically, with this change, Hubot would dispatch three different times to StackStorm:

1. Once for the issue key `SERVICEDESK-1234`
2. Once for the issue key `INFRASTRUCTURE-4321`
3. Once for the issue key `SERVICEDESK-1235`

The `regex_flags` key is exposed to hubot-stackstorm through StackStorm's API, so H-S can compile the regular expression with the appropriate flags.

# Extensibility #

Our current actions simply respond with a blob of the the issue description in Slack, saving our users a round trip to Jira (which could itself include a login) to read the issue. However, the exact action is not limited to this.

Because StackStorm exposes the YAML root keys over its API, hubot-stackstorm can pick up keys that were not initially exposed, such as the `regex_flags` key. This key allows pack developers to specify the flags with which the representation regex should be compiled. By passing the `g` flag, the regex is compiled to match the message multiple times, and each match then gets dispatched to StackStorm. Other regex flags can also be passed to XRegExp using this mechanism.

Finally, with all of that plumbing in place, I have H-S pull the action aliases and use Hubot's `hear()` function so chat bots can respond to appropriate messages even if they were not @mentioned directly.

# Additional Considerations #

I changed the regex engine from Node.js' default regex engine to the XRegExp engine. The original Javascript regex engine does not support named group captures at all, but Python's standard `re` module does. When pack authors specify named groups using Python's extension syntax (eg: `(?P<group_name>...)`), the native Javascript regex engine barfs on the Python-specific named group capture. The XRegExp package properly interprets the Python named capture group syntax, which allows named capture groups in the compiled regex. XRegExp is a wrapper around the built-in Javascript regex engine (it does a little bookkeeping to pair up a numbered capture group with a named capture group), so its both backwards compatible from a matching/calling perspective and from a performance perspective. By using XRegExp, we avoid having to remove or convert Python's named capture group syntax, so the Python-compatible regex that pack authors are already comfortable writing can also automatically be used in Hubot.

# Tests #

I have added tests for `lib/command_factory.js`, but I found it difficult to add automated tests `scripts/stackstorm.js`. I have tested it manually by deploying this code to our dev StackStorm server and running messages into it via Slack.

If you have any testing suggestions for me I am very interested.

#### Coverage ####

According to the coverage report, the tests I added to `tests/test-command-factory.js` have covered 100% of the code I changed in `lib/command_factory.js`.

# Motivation #

This PR sets the stage for some of our changes to the [StackStorm Jira pack](https://github.com/StackStorm-Exchange/stackstorm-jira). We are working on upstreaming those changes as well, once these changes are put into place.

Our final intent is to have a JiraBot listen in on the channel, and when anybody mentions a Jira issue (without necessarily @-mentioning the bot directly), the JiraBot pulls the issue summary from Jira and dumps it into the channel (with pretty formatting, of course, once #147 is merged in).

# Final Notes #

This is some of the first in-depth Javascript I have written, so if I am not following coding conventions, or if there are better ways to implement things, please let me know.

Also, I have not tested this on anything other than Mac OS X with Node.js v8.4.0.

As always, I'm happy to answer any questions or respond to any comments, criticisms, or discussion. Thanks!