### PR TITLE
Use the files key in package.json to restrict the files that are published to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,10 @@
   },
   "engines": {
     "node": ">=8.0 <11.0"
-  }
+  },
+  "files": [
+    "/index.js",
+    "/lib",
+    "/scripts"
+  ]
 }


### PR DESCRIPTION
Without this change npm publish tries to publish many unnecessary files:

```
$ npm publish --dry-run
npm notice
npm notice 📦  hubot-stackstorm@0.9.0
npm notice === Tarball Contents ===
npm notice 1.6kB  package.json
npm notice 48B    .mversionrc
npm notice 302B   .travis.yml
npm notice 3.1kB  CHANGELOG.rst
npm notice 1.3kB  gulpfile.js
npm notice 1.3kB  index.js
npm notice 397B   jshint.json
npm notice 11.4kB LICENSE.txt
npm notice 5.1kB  README.md
npm notice 4.3kB  lib/command_factory.js
npm notice 1.2kB  lib/format_command.js
npm notice 5.6kB  lib/format_data.js
npm notice 13.5kB lib/post_data.js
npm notice 1.6kB  lib/slack_monkey_patch.js
npm notice 9.0kB  lib/slack-messages.js
npm notice 3.9kB  lib/utils.js
npm notice 14.6kB scripts/stackstorm.js
npm notice 1.2kB  tests/dummy-adapters.js
npm notice 1.5kB  tests/dummy-robot.js
npm notice 760B   tests/fixtures/aliases.json
npm notice 5.7kB  tests/test-command-factory.js
npm notice 1.7kB  tests/test-formatcommand.js
npm notice 6.9kB  tests/test-formatdata.js
npm notice 11.2kB tests/test-postdata.js
npm notice 12.6kB tests/test-slack-messages.js
npm notice 3.0kB  tests/test-st2bot-setup.js
npm notice 3.6kB  tests/test-twofactor.js
npm notice 5.3kB  tests/test-utils.js
npm notice === Tarball Details ===
npm notice name:          hubot-stackstorm
npm notice version:       0.9.0
npm notice package size:  27.5 kB
npm notice unpacked size: 131.7 kB
npm notice shasum:        7ad05214028257f3d521d062368c6c9baeabb344
npm notice integrity:     sha512-T9ddM5sjbiTsi[...]Rp+j9G4yLDbWg==
npm notice total files:   28
npm notice
+ hubot-stackstorm@0.9.0
```

With this change only specific files are published:

```
$ npm publish --dry-run
npm notice
npm notice 📦  hubot-stackstorm@0.9.0
npm notice === Tarball Contents ===
npm notice 1.7kB  package.json
npm notice 3.1kB  CHANGELOG.rst
npm notice 1.3kB  index.js
npm notice 11.4kB LICENSE.txt
npm notice 5.1kB  README.md
npm notice 4.3kB  lib/command_factory.js
npm notice 1.2kB  lib/format_command.js
npm notice 5.6kB  lib/format_data.js
npm notice 13.5kB lib/post_data.js
npm notice 1.6kB  lib/slack_monkey_patch.js
npm notice 9.0kB  lib/slack-messages.js
npm notice 3.9kB  lib/utils.js
npm notice 14.6kB scripts/stackstorm.js
npm notice === Tarball Details ===
npm notice name:          hubot-stackstorm
npm notice version:       0.9.0
npm notice package size:  19.7 kB
npm notice unpacked size: 76.2 kB
npm notice shasum:        b812937ba20c4e0b090646dc5202b318e7145f75
npm notice integrity:     sha512-bIXSUdF0UtofX[...]mftR8sF7DlwnA==
npm notice total files:   13
npm notice
+ hubot-stackstorm@0.9.0
```