### PR TITLE
Prefer 'ST2_API_URL' ENV instead of 'ST2_API' for consistency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 in development
 --------------
 
+0.9.1
+-----
+* Rename ENV variable `ST2_API` -> `ST2_API_URL` for consistency, keep `ST2_API` for backwards compatibility (improvement)
+
 0.9.0
 -----
 * Remove support for Yammer (removal)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ After that's done, you are ready to start your bot.
 To configure the plugin behavior, the following environment variable can be
 specified when running hubot:
 
-* `ST2_API` - URL to the StackStorm API endpoint.
+* `ST2_API_URL` - URL to the StackStorm API endpoint.
 * `ST2_WEBUI_URL` - Base URL to the WebUI. If provided, link to the execution
   history will be provided in the chat after every execution (optional).
 * `ST2_AUTH_USERNAME` - API credentials - username (optional).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-stackstorm",
   "description": "A hubot plugin for integrating with StackStorm event-driven infrastructure automation platform.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "StackStorm, Inc. <info@stackstorm.com>",
   "license": "Apache-2.0",
   "keywords": [

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -45,7 +45,14 @@ var _ = require('lodash'),
   ;
 
 // Setup the Environment
-env.ST2_API_URL = env.ST2_API_URL || env.ST2_API || 'http://localhost:9101';
+env.ST2_API_URL = env.ST2_API_URL || null;
+if (!env.ST2_API_URL) {
+  if (env.ST2_API) {
+    robot.logger.warning("ST2_API is now deprecated and will be removed in a future release. Instead, please use the ST2_API_URL environment variable.");
+  }
+  env.ST2_API_URL = env.ST2_API || 'http://localhost:9101';
+}
+
 env.ST2_ROUTE = env.ST2_ROUTE || null;
 env.ST2_WEBUI_URL = env.ST2_WEBUI_URL || null;
 

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -20,7 +20,7 @@
 //
 //
 // Configuration:
-//   ST2_API - FQDN + port to StackStorm endpoint
+//   ST2_API_URL - FQDN + port to StackStorm endpoint
 //   ST2_ROUTE - StackStorm notification route name
 //   ST2_COMMANDS_RELOAD_INTERVAL - Reload interval for commands
 //
@@ -45,7 +45,7 @@ var _ = require('lodash'),
   ;
 
 // Setup the Environment
-env.ST2_API = env.ST2_API || 'http://localhost:9101';
+env.ST2_API_URL = env.ST2_API_URL || env.ST2_API || 'http://localhost:9101';
 env.ST2_ROUTE = env.ST2_ROUTE || null;
 env.ST2_WEBUI_URL = env.ST2_WEBUI_URL || null;
 
@@ -104,7 +104,7 @@ module.exports = function(robot) {
 
   var promise = Promise.resolve();
 
-  var url = utils.parseUrl(env.ST2_API);
+  var url = utils.parseUrl(env.ST2_API_URL);
 
   var opts = {
     protocol: url.protocol,
@@ -234,7 +234,7 @@ module.exports = function(robot) {
       })
       .catch(function (err) {
         var error_msg = 'Failed to retrieve commands from "%s": %s';
-        robot.logger.error(util.format(error_msg, env.ST2_API, err.message));
+        robot.logger.error(util.format(error_msg, env.ST2_API_URL, err.message));
       });
   };
 


### PR DESCRIPTION
> This is spot during the K8s work https://github.com/StackStorm/st2-dockerfiles/pull/19

For consistency with other ENV variables (see https://docs.stackstorm.com/reference/cli.html#configuration), rename `ST2_API` -> `ST2_API_URL`.
The change still supports old `ST2_API` for backwards compatibility if someone is using `hubot-stackstorm` externally.

---

`st2chatops` change to `st2chatops.env` will come next.