### PR TITLE
Further tweaks for #168

### DIFF
--- a/lib/slack-messages.js
+++ b/lib/slack-messages.js
@@ -18,37 +18,6 @@
 
 var utils = require('./utils.js');
 
-// Polyfill from:
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-if (typeof Object.assign !== 'function') {
-  // Must be writable: true, enumerable: false, configurable: true
-  Object.defineProperty(Object, "assign", {
-    value: function assign(target, varArgs) { // .length of function is 2
-      if (target === null) { // TypeError if undefined or null
-        throw new TypeError('Cannot convert undefined or null to object');
-      }
-
-      var to = Object(target);
-
-      for (var index = 1; index < arguments.length; index++) {
-        var nextSource = arguments[index];
-
-        if (nextSource !== null) { // Skip over if undefined or null
-          for (var nextKey in nextSource) {
-            // Avoid bugs when hasOwnProperty is shadowed
-            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
-              to[nextKey] = nextSource[nextKey];
-            }
-          }
-        }
-      }
-      return to;
-    },
-    writable: true,
-    configurable: true
-  });
-}
-
 var buildMessagesWithChunkedFieldValue = function (msg) {
   var msgs;
 

--- a/lib/slack_monkey_patch.js
+++ b/lib/slack_monkey_patch.js
@@ -27,6 +27,18 @@ function patchSendMessage(robot) {
   // formatted and parsed on the server side.
   // NOTE / TODO: We can get rid of this nasty patch once our node-slack-client and hubot-slack pull
   // requests are merged.
+  // This code was refactored in https://github.com/StackStorm/hubot-stackstorm/pull/6
+  // which was opened and merged by Kami on 2015-06-04.
+  // As of 2019-05-22, these were the PRs I could find for the node-slack-client
+  // hubot-slack repositories:
+  // * https://github.com/slackapi/node-slack-sdk/pull/42
+  //   - which was closed during a refactor and converted into an issue:
+  //     https://github.com/slackapi/node-slack-sdk/issues/138
+  // * https://github.com/slackapi/hubot-slack/pull/544
+  //   - which was opened on 2018-11-14, which seems to be too late to actually
+  //     apply to this code
+  // So...I'm not entirely sure this monkey patch is still necessary.
+  // End-to-end testing is required to figure out for sure.
   if (robot.adapter && robot.adapter.constructor && robot.adapter.constructor.name === 'SlackBot') {
     for (var channel in robot.adapter.client.channels) {
       robot.adapter.client.channels[channel].sendMessage = sendMessageRaw.bind(robot.adapter.client.channels[channel]);

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
+    "chai-string": "^1.5.0",
     "gulp": "^3.9.0",
     "gulp-jshint": "^2.1.0",
     "gulp-mocha": "^6.0.0",
@@ -46,6 +47,7 @@
     "jshint": "^2.7.0",
     "jshint-stylish": "^2.0.0",
     "log": "1.4.0",
+    "mocked-env": "^1.2.4",
     "nock": "^10.0.0",
     "nyc": "^13.0.1",
     "sinon": "^6.3.5",

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -127,20 +127,12 @@ module.exports = function(robot) {
     };
   }
 
-  var api = st2client(opts);
+  var api_client = st2client(opts);
 
   if (env.ST2_API_KEY) {
-    api.setKey({ key: env.ST2_API_KEY });
+    api_client.setKey({ key: env.ST2_API_KEY });
   } else if (env.ST2_AUTH_TOKEN) {
-    api.setToken({ token: env.ST2_AUTH_TOKEN });
-  }
-
-  function hubotErrorCallback(error, res) {
-    // Hubot alrady logged the stack trace before call this callback function, 
-    // only error message will be logged here
-    robot.logger.error("Caught error from hubot: " + error.message);
-
-    stop();
+    api_client.setToken({ token: env.ST2_AUTH_TOKEN });
   }
 
   function exitProcessWithLog(errorMsg, err) {
@@ -155,7 +147,7 @@ module.exports = function(robot) {
   }
 
   function authenticate() {
-    api.removeListener('expiry', authenticate);
+    api_client.removeListener('expiry', authenticate);
 
     // API key gets precedence 1
     if (env.ST2_API_KEY) {
@@ -172,7 +164,7 @@ module.exports = function(robot) {
 
     var url = utils.parseUrl(env.ST2_AUTH_URL);
 
-    var client = st2client({
+    var auth_client = st2client({
       auth: {
         protocol: url.protocol,
         host: url.hostname,
@@ -181,11 +173,11 @@ module.exports = function(robot) {
       }
     });
 
-    return client.authenticate(env.ST2_AUTH_USERNAME, env.ST2_AUTH_PASSWORD)
+    return auth_client.authenticate(env.ST2_AUTH_USERNAME, env.ST2_AUTH_PASSWORD)
       .then(function (token) {
         robot.logger.info('Token received. Expiring ' + token.expiry);
-        api.setToken(token);
-        client.on('expiry', authenticate);
+        api_client.setToken(token);
+        auth_client.on('expiry', authenticate);
       })
       .catch(function (err) {
         exitProcessWithLog('Failed to authenticate: ', err);
@@ -222,7 +214,7 @@ module.exports = function(robot) {
 
     var opts = Object.assign({exitOnFailure: false}, opts);
 
-    api.actionAlias.list()
+    api_client.actionAlias.list()
       .then(function (aliases) {
         // Remove all the existing commands
         command_factory.removeCommands();
@@ -286,7 +278,7 @@ module.exports = function(robot) {
   var sendAliasExecutionRequest = function (msg, payload) {
     robot.logger.debug('Sending command payload:', JSON.stringify(payload));
 
-    api.aliasExecution.create(payload)
+    api_client.aliasExecution.create(payload)
       .then(function (res) { sendAck(msg, res); })
       .catch(function (err) {
         // Compatibility with older StackStorm versions
@@ -330,7 +322,7 @@ module.exports = function(robot) {
       var twofactor_id = uuid.v4();
       robot.logger.debug('Requested an action that requires 2FA. Guid: ' + twofactor_id);
       msg.send(TWOFACTOR_MESSAGE);
-      api.executions.create({
+      api_client.executions.create({
         'action': env.HUBOT_2FA,
         'parameters': {
           'uuid': twofactor_id,
@@ -392,7 +384,8 @@ module.exports = function(robot) {
 
   function start() {
     robot.error(hubotErrorCallback);
-    api.stream.listen().catch(function (err) {
+
+    api_client.stream.listen().catch(function (err) {
       exitProcessWithLog('Unable to connect to stream: ', err);
     }).then(function (source) {
       source.onerror = function (err) {
@@ -449,7 +442,7 @@ module.exports = function(robot) {
 
   function stop() {
     clearInterval(commands_load_interval);
-    api.stream.listen().then(function (source) {
+    api_client.stream.listen().then(function (source) {
       source.removeAllListeners();
       source.close();
     });

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -383,6 +383,7 @@ module.exports = function(robot) {
     robot.error(logErrorAndExit);
 
     api_client.stream.listen().then(function (stream) {
+      _stream = stream;  // save stream for use in stop()
       stream.on('error', function (err) {
         logErrorAndExit(err);
       });
@@ -431,10 +432,11 @@ module.exports = function(robot) {
 
   function stop() {
     clearInterval(commands_load_interval);
-    api_client.stream.listen().then(function (source) {
-      source.removeAllListeners();
-      source.close();
-    });
+
+    if (_stream) {
+      _stream.removeAllListeners();
+      _stream.close();
+    }
 
     robot.shutdown();
     process.exit(1);

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -191,8 +191,9 @@ module.exports = function(robot) {
         !(env.ST2_AUTH_USERNAME && env.ST2_AUTH_PASSWORD && env.ST2_AUTH_URL)) {
       robot.logger.error('Environment variables ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD and ST2_AUTH_URL should only be used together.');
       stop();
+    } else {
+      promise = authenticate();
     }
-    promise = authenticate();
   }
 
   // Pending 2-factor auth commands

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -385,10 +385,9 @@ module.exports = function(robot) {
     api_client.stream.listen().catch(function (err) {
       exitProcessWithLog('Unable to connect to stream: ', err);
     }).then(function (source) {
-      source.onerror = function (err) {
-        // TODO: squeeze a little bit more info out of eventsource.js
+      source.on('error', function (err) {
         logErrorAndExit(err);
-      };
+      });
       source.addEventListener('st2.announcement__chatops', function (e) {
         var data;
 

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -339,7 +339,7 @@ module.exports = function(robot) {
   };
 
   robot.respond(/([\s\S]+?)$/i, function(msg) {
-    var command, result, command_name, format_string, action_alias;
+    var command, result;
 
     // Normalize the command and remove special handling provided by the chat service.
     // e.g. slack replace quote marks with left double quote which would break behavior.
@@ -352,9 +352,7 @@ module.exports = function(robot) {
       return;
     }
 
-    command_name = result[0];
-    format_string = result[1];
-    action_alias = result[2];
+    var [command_name, format_string, action_alias] = result;
 
     executeCommand(msg, command_name, format_string, command, action_alias);
   });

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -100,22 +100,20 @@ var TWOFACTOR_MESSAGE = "This action requires two-factor auth! Waiting for your 
 module.exports = function(robot) {
   slack_monkey_patch.patchSendMessage(robot);
 
-  var self = this;
-
-  var promise = Promise.resolve();
-
   if (env.ST2_API) {
     robot.logger.warning("ST2_API is deprecated and will be removed in a future releases. Instead, please use the ST2_API_URL environment variable.");
   }
-  var url = utils.parseUrl(env.ST2_API_URL);
-
-  var opts = {
-    protocol: url.protocol,
-    host: url.hostname,
-    port: url.port,
-    prefix: url.path,
-    rejectUnauthorized: false
-  };
+  var _stream = null,
+    self = this,
+    promise = Promise.resolve(),
+    url = utils.parseUrl(env.ST2_API_URL),
+    opts = {
+      protocol: url.protocol,
+      host: url.hostname,
+      port: url.port,
+      prefix: url.path,
+      rejectUnauthorized: false
+    };
 
   if (env.ST2_STREAM_URL) {
     var stream_url = utils.parseUrl(env.ST2_STREAM_URL);

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -210,10 +210,8 @@ module.exports = function(robot) {
   // handler to manage per adapter message post-ing.
   var postDataHandler = postData.getDataPostHandler(robot.adapterName, robot, formatter);
 
-  var loadCommands = function(opts) {
-    robot.logger.info('Loading commands....');
-
-    var opts = Object.assign({exitOnFailure: false}, opts);
+  var loadCommands = function() {
+    robot.logger.info('Loading commands...');
 
     api_client.actionAlias.list()
       .then(function (aliases) {
@@ -249,10 +247,8 @@ module.exports = function(robot) {
         robot.logger.info(command_factory.st2_hubot_commands.length + ' commands are loaded');
       })
       .catch(function (err) {
-        var error_msg = 'Failed to retrieve commands from ' + env.ST2_API_URL + ' ';
-        if (opts.exitOnFailure) {
-          logErrorAndExit(err);
-        }
+        robot.logger.error('Failed to retrieve commands from ' + env.ST2_API_URL);
+        logErrorAndExit(err);
       });
   };
 
@@ -428,7 +424,7 @@ module.exports = function(robot) {
     });
 
     // Initial command loading
-    loadCommands({exitOnFailure: true});
+    loadCommands();
 
     // Add an interval which tries to re-load the commands
     commands_load_interval = setInterval(loadCommands.bind(self), (env.ST2_COMMANDS_RELOAD_INTERVAL * 1000));

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -382,9 +382,7 @@ module.exports = function(robot) {
   function start() {
     robot.error(logErrorAndExit);
 
-    api_client.stream.listen().catch(function (err) {
-      exitProcessWithLog('Unable to connect to stream: ', err);
-    }).then(function (source) {
+    api_client.stream.listen().then(function (source) {
       source.on('error', function (err) {
         logErrorAndExit(err);
       });

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -382,11 +382,11 @@ module.exports = function(robot) {
   function start() {
     robot.error(logErrorAndExit);
 
-    api_client.stream.listen().then(function (source) {
-      source.on('error', function (err) {
+    api_client.stream.listen().then(function (stream) {
+      stream.on('error', function (err) {
         logErrorAndExit(err);
       });
-      source.addEventListener('st2.announcement__chatops', function (e) {
+      stream.addEventListener('st2.announcement__chatops', function (e) {
         var data;
 
         robot.logger.debug('Chatops message received:', e.data);
@@ -401,7 +401,7 @@ module.exports = function(robot) {
       });
 
       if (env.HUBOT_2FA) {
-        source.addEventListener('st2.announcement__2fa', function (e) {
+        stream.addEventListener('st2.announcement__2fa', function (e) {
           var data;
 
           robot.logger.debug('Successfull two-factor auth:', e.data);

--- a/tests/dummy-logger.js
+++ b/tests/dummy-logger.js
@@ -17,21 +17,44 @@ limitations under the License.
 
 "use strict";
 
-var Logger = require('./dummy-logger.js');
 
-function Robot(name, adapter, enable_logging) {
-  this.logger = new Logger(enable_logging);
-  this.name = name;
-  this.commands = [];
-  this.adapter = adapter;
 
-  this.messageRoom = function(recipient, data) {
-    return;
-  }
+function Logger(enabled) {
+  this.enabled = enabled;
+  this.logs = {
+    error: [],
+    warning: [],
+    info: [],
+    debug: []
+  };
 
-  this.emit = function(event, data) {
-    return;
-  }
+  this.error = function(msg) {
+    if (!this.enabled) {
+      return;
+    }
+    this.logs.error.push(msg);
+  };
+
+  this.warning = function(msg) {
+    if (!this.enabled) {
+      return;
+    }
+    this.logs.warning.push(msg);
+  };
+
+  this.info = function(msg) {
+    if (!this.enabled) {
+      return;
+    }
+    this.logs.info.push(msg);
+  };
+
+  this.debug = function(msg) {
+    if (!this.enabled) {
+      return;
+    }
+    this.logs.debug.push(msg);
+  };
 }
 
-module.exports = Robot;
+module.exports = Logger;

--- a/tests/dummy-robot.js
+++ b/tests/dummy-robot.js
@@ -19,11 +19,12 @@ limitations under the License.
 
 var Logger = require('./dummy-logger.js');
 
-function Robot(name, adapter, enable_logging) {
+function Robot(name, adapter, enable_logging, robot_name) {
   this.logger = new Logger(enable_logging);
   this.name = name;
   this.commands = [];
   this.adapter = adapter;
+  this.robot_name = robot_name;
 
   this.messageRoom = function(recipient, data) {
     return;

--- a/tests/test-st2-invalid-auth.js
+++ b/tests/test-st2-invalid-auth.js
@@ -1,0 +1,142 @@
+/*
+ Licensed to the StackStorm, Inc ('StackStorm') under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*jshint quotmark:false*/
+/*jshint -W030*/
+/*global describe, it, before, after*/
+'use strict';
+
+var chai = require("chai"),
+  expect = chai.expect,
+  chaiString = require("chai-string"),
+  sinon = require('sinon'),
+  sinonChai = require('sinon-chai'),
+  mockedEnv = require('mocked-env'),
+  Robot = require("hubot/src/robot"),
+  Logger = require('./dummy-logger.js');
+
+chai.use(sinonChai);
+chai.use(chaiString);
+
+global.process.exit = sinon.spy();
+
+describe("invalid st2 credential configuration", function() {
+  var robot = new Robot(null, "mock-adapter", false, "Hubot");
+  robot.logger = new Logger(true);
+  var restore_env = null,
+    info_spy = sinon.spy(robot.logger, 'info'),
+    error_spy = sinon.spy(robot.logger, 'error');
+
+  afterEach(function() {
+    restore_env && restore_env();
+    error_spy.resetHistory();
+    info_spy.resetHistory();
+    // Remove stackstorm.js from the require cache
+    // https://medium.com/@gattermeier/invalidate-node-js-require-cache-c2989af8f8b0
+    delete require.cache[require.resolve("../scripts/stackstorm.js")];
+  });
+
+  it("should raise exception with null auth URL", function(done) {
+    // Mock process.env for all modules
+    // https://glebbahmutov.com/blog/mocking-process-env/
+    restore_env = mockedEnv({
+      ST2_AUTH_USERNAME: 'nonexistent-st2-auth-username',
+      ST2_AUTH_PASSWORD: 'nonexistent-st2-auth-password'
+    });
+
+    // Load script under test
+    var stackstorm = require("../scripts/stackstorm.js");
+    stackstorm(robot).then(function (stop) {
+      expect(error_spy).to.have.been.calledOnce;
+      expect(error_spy.firstCall.args[0]).include('Environment variables ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD and ST2_AUTH_URL should only be used together.');
+
+      stop();
+
+      done();
+    }).catch(function (err) {
+      console.log(err);
+      done(err);
+    });
+  });
+
+  it("should raise exception with bad auth URL", function(done) {
+    restore_env = mockedEnv({
+      ST2_AUTH_URL: 'https://nonexistent-st2-auth-url:9101',
+      ST2_AUTH_USERNAME: 'nonexistent-st2-auth-username',
+      ST2_AUTH_PASSWORD: 'nonexistent-st2-auth-password'
+    });
+
+    // Load script under test
+    var stackstorm = require("../scripts/stackstorm.js");
+    stackstorm(robot).then(function (stop) {
+      expect(error_spy).to.have.callCount(4);
+      expect(error_spy.args[0][0]).to.equal(undefined);
+      expect(error_spy.args[1][0]).to.startWith('Failed to retrieve commands from');
+      expect(error_spy.args[2][0]).to.include('connect ECONNREFUSED 127.0.0.1:9101')
+      expect(error_spy.args[3][0]).to.include('getaddrinfo ENOTFOUND nonexistent-st2-auth-url nonexistent-st2-auth-url:9101');
+
+      stop();
+
+      done();
+    }).catch(function (err) {
+      console.log(err);
+      done(err);
+    });
+  });
+
+  it("should raise exception with bad API key", function(done) {
+    restore_env = mockedEnv({
+      ST2_API_KEY: 'aaa'
+    });
+
+    // Load script under test
+    var stackstorm = require("../scripts/stackstorm.js");
+    stackstorm(robot).then(function (stop) {
+      expect(info_spy).to.have.been.calledTwice;
+      expect(info_spy).to.have.been.calledWith('Using ST2_API_KEY as authentication. Expiry will lead to bot exit.');
+      expect(info_spy).to.have.been.calledWith('Loading commands...');
+
+      stop();
+
+      done();
+    }).catch(function (err) {
+      console.log(err);
+      done(err);
+    });
+  });
+
+  it("should raise exception with bad auth token", function(done) {
+    restore_env = mockedEnv({
+      ST2_AUTH_TOKEN: 'aaa'
+    });
+
+    // Load script under test
+    var stackstorm = require("../scripts/stackstorm.js");
+    stackstorm(robot).then(function (stop) {
+      expect(info_spy).to.have.been.calledTwice;
+      expect(info_spy).to.have.been.calledWith('Using ST2_AUTH_TOKEN as authentication. Expiry will lead to bot exit.');
+      expect(info_spy).to.have.been.calledWith('Loading commands...');
+
+      stop();
+
+      done();
+    }).catch(function (err) {
+      console.log(err);
+      done(err);
+    });
+  });
+});

--- a/tests/test-st2-invalid-auth.js
+++ b/tests/test-st2-invalid-auth.js
@@ -41,6 +41,10 @@ describe("invalid st2 credential configuration", function() {
     info_spy = sinon.spy(robot.logger, 'info'),
     error_spy = sinon.spy(robot.logger, 'error');
 
+  beforeEach(function () {
+    process.exit.resetHistory();
+  });
+
   afterEach(function() {
     restore_env && restore_env();
     error_spy.resetHistory();
@@ -48,6 +52,10 @@ describe("invalid st2 credential configuration", function() {
     // Remove stackstorm.js from the require cache
     // https://medium.com/@gattermeier/invalidate-node-js-require-cache-c2989af8f8b0
     delete require.cache[require.resolve("../scripts/stackstorm.js")];
+  });
+
+  after(function () {
+    process.exit.restore && process.exit.restore();
   });
 
   it("should raise exception with null auth URL", function(done) {
@@ -63,6 +71,8 @@ describe("invalid st2 credential configuration", function() {
     stackstorm(robot).then(function (stop) {
       expect(error_spy).to.have.been.calledOnce;
       expect(error_spy.firstCall.args[0]).include('Environment variables ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD and ST2_AUTH_URL should only be used together.');
+      expect(process.exit).to.have.been.calledOnce;
+      expect(process.exit.args[0][0]).to.equal(1);
 
       stop();
 
@@ -88,6 +98,8 @@ describe("invalid st2 credential configuration", function() {
       expect(error_spy.args[1][0]).to.startWith('Failed to retrieve commands from');
       expect(error_spy.args[2][0]).to.include('connect ECONNREFUSED 127.0.0.1:9101')
       expect(error_spy.args[3][0]).to.include('getaddrinfo ENOTFOUND nonexistent-st2-auth-url nonexistent-st2-auth-url:9101');
+      expect(process.exit).to.have.been.calledOnce;
+      expect(process.exit.args[0][0]).to.equal(1);
 
       stop();
 


### PR DESCRIPTION
Final tweaks for #168. This should be merged into the `issue-124/exit_on_failures` branch before #168 is merged in. That PR is looking pretty good, but there were a lot of places we can/should refactor, and some places we absolutely needed to refactor so we can test the new changes.

This PR:

* Adds large comment in `slack_monkey_patch.js` for future developers to help determine if the monkey patching is still necessary.
* Removes `Object.assign()` polyfill from `lib/slack-messages.js` - **this requires node.js version > 8.3.0**
* Breaks out the dummy `Logger` out from `tests/dummy-robot.js` into its own module
* Add `robot_name` argument to dummy `Robot` mock, to better mirror actual `Robot` constructor
* Rename `api` and `client` variables (both `st2client.js` instances) to `api_client` and `auth_client` in `scripts/stackstorm.js`
* Coalesce multiple `var` declarations into one
* Combine and rename `hubotErrorCallback` and `exitProcessWithLog` into `LogErrorAndExit`, which is now used to handle uncaught exceptions within Hubot, and is explicitly called when we cannot recover from re/connection attempts
* Refactor `loadCommands` to not accept an options object parameter, since we should always simply die if we can't connect or load commands
* Move `promise = authenticate();` into an `else` block to prevent it from running while the robot is stopping
* Use array unpacking (`var [var1, var2, var3] = [1, 2, 3];`) since we can now that we're using Node.js > 8
* Refactor (eventsource) stream error handling to properly register a callback instead of overwriting the `onerror` handler
* Remove ST2 stream error handler since we now have an `uncaughtException` handler for hubot
* Rename eventsource's `source` parameter to `stream`, since that makes slightly more sense
* Close down the eventsource stream instead of creating a new one that immediately gets shut down
* Add a few unit tests to test if hubot is stopped if certain environment variables aren't valid