### PR TITLE
Support pagination for action alias.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 in development
 --------------
 
+0.9.4
+-----
+* Add pagination support for action aliases - fixes #158 (bug fix)
+
 0.9.3
 -----
 * Add initial support for Microsoft Teams via BotFramework (new feature)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "coffee-script": "1.12.7",
     "lodash": "^4.17.11",
     "rsvp": "^4.8.4",
-    "st2client": "^1.1.1",
+    "st2client": "^1.1.2",
     "truncate": "^2.0.1",
     "uuid": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-stackstorm",
   "description": "A hubot plugin for integrating with StackStorm event-driven infrastructure automation platform.",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "author": "StackStorm, Inc. <info@stackstorm.com>",
   "license": "Apache-2.0",
   "keywords": [

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -201,7 +201,7 @@ module.exports = function(robot) {
   var loadCommands = function() {
     robot.logger.info('Loading commands....');
 
-    api.actionAlias.list()
+    api.actionAlias.list({limit: -1})
       .then(function (aliases) {
         // Remove all the existing commands
         command_factory.removeCommands();


### PR DESCRIPTION
Fixes https://github.com/StackStorm/hubot-stackstorm/issues/158 
Setup `limit=-1` to retrieve all the action alias records.