### PR TITLE
Move babel-eslint to devDependencies instead of dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ in development
 * Move babel-eslint dependency to devDependencies (bug fix)
 
 0.9.6
+-----
 * Don't consider failed alias execution as a critical reason to exit hubot (bug fix)
 
 0.9.5

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 in development
 --------------
 
+* Move babel-eslint dependency to devDependencies (bug fix)
+
 0.9.6
 * Don't consider failed alias execution as a critical reason to exit hubot (bug fix)
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "url": "https://github.com/StackStorm/hubot-stackstorm/issues"
   },
   "dependencies": {
-    "babel-eslint": "^10.0.1",
     "cli-table": "<=1.0.0",
     "coffee-register": "1.0.0",
     "coffee-script": "1.12.7",
@@ -35,6 +34,7 @@
     "hubot": "3.x"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.16.0",


### PR DESCRIPTION
Should help reduce the size of the diff of `npm-shrinkwrap.json` in https://github.com/StackStorm/st2chatops/pull/128.