### PR TITLE
Don't consider failed alias execution as a critical reason to exit hubot 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 in development
 --------------
 
+0.9.6
+* Don't consider failed alias execution as a critical reason to exit hubot (bug fix)
 
 0.9.5
 -----

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-stackstorm",
   "description": "A hubot plugin for integrating with StackStorm event-driven infrastructure automation platform.",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "author": "StackStorm, Inc. <info@stackstorm.com>",
   "license": "Apache-2.0",
   "keywords": [

--- a/scripts/stackstorm.js
+++ b/scripts/stackstorm.js
@@ -312,7 +312,6 @@ module.exports = function(robot) {
             color: '#F35A00'
           }
         });
-        throw err;
       });
   };
 


### PR DESCRIPTION
Fixes #182