### PR TITLE
Redo adapter inheritance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,10 @@ in development
 * Move babel-eslint dependency to devDependencies (bug fix)
 * Small refactor and more tests (for ``scripts/stackstorm.js``) (improvement)
 * Refactor chat providers into their own modules (improvement)
-* Modernize directory structure to be more consistent with other hubot plugins (improvement)
-* Split out the functionality of ``src/stackstorm.js`` into ``stackstorm_api.js`` and refactor it be a JS old style class with a wrapper (improvement)
+* Modernize directory structure to be more consistent with other hubot plugins
+  (improvement)
+* Split out the functionality of ``src/stackstorm.js`` into ``stackstorm_api.js`` and refactor it
+  be a JS old style class with a wrapper (improvement)
 
 0.9.6
 -----
@@ -16,12 +18,15 @@ in development
 
 0.9.5
 -----
-* Exit hubot on invalid, expired ``ST2_API_KEY`` / ``ST2_AUTH_TOKEN`` or any other Unauthorized response from st2 server (bug fix)
-* When st2 username/password is used, re-generate st2 auth token in advance, giving enough time for request to complete, st2client.js (bug fix)
+* Exit hubot on invalid, expired ``ST2_API_KEY`` / ``ST2_AUTH_TOKEN`` or any other Unauthorized
+  response from st2 server (bug fix)
+* When st2 username/password is used, re-generate st2 auth token in advance, giving enough time for
+  request to complete, st2client.js (bug fix)
 
 0.9.4
 -----
-* Exit hubot on unhandled promise rejections and uncaught exceptions, usually caused by unrecoverable errors (bug fix)
+* Exit hubot on unhandled promise rejections and uncaught exceptions, usually caused by
+  unrecoverable errors (bug fix)
 * Add pagination support for action aliases - fixes #158 (bug fix)
 
 0.9.3
@@ -31,7 +36,8 @@ in development
 
 0.9.2
 -----
-* Rename ENV variable ``ST2_API`` -> ``ST2_API_URL`` for consistency, keep ``ST2_API`` for backwards compatibility (improvement)
+* Rename ENV variable ``ST2_API`` -> ``ST2_API_URL`` for consistency, keep ``ST2_API`` for
+  backwards compatibility (improvement)
 
 0.9.1
 -----
@@ -105,7 +111,8 @@ in development
 0.2.2
 -----
 
-* Log a better error message if we fail to load the commands because of the StackStorm API unavailability.
+* Log a better error message if we fail to load the commands because of the StackStorm API
+  unavailability.
 
 0.2.1
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ in development
 * Modernize directory structure to be more consistent with other hubot plugins
   (improvement)
 * Split out the functionality of ``src/stackstorm.js`` into ``stackstorm_api.js`` and refactor it
-  be a JS old style class with a wrapper (improvement)
+  to be a JS old style class with a wrapper (improvement)
 
 0.9.6
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,13 +4,13 @@ Changelog
 in development
 --------------
 
-* Move babel-eslint dependency to devDependencies (bug fix)
-* Small refactor and more tests (for ``scripts/stackstorm.js``) (improvement)
-* Refactor chat providers into their own modules (improvement)
-* Modernize directory structure to be more consistent with other hubot plugins
+* Move babel-eslint dependency to devDependencies [PR #180] (bug fix)
+* Small refactor and more tests (for ``scripts/stackstorm.js``) [PR #185] (improvement)
+* Refactor chat providers into their own modules [PR #186] (improvement)
+* Modernize directory structure to be more consistent with other hubot plugins [PR #186, PR #191]
   (improvement)
 * Split out the functionality of ``src/stackstorm.js`` into ``stackstorm_api.js`` and refactor it
-  to be a JS old style class with a wrapper (improvement)
+  to be a JS old style class with a wrapper [PR #187, PR #190] (improvement)
 
 0.9.6
 -----

--- a/src/lib/adapters/mattermost.js
+++ b/src/lib/adapters/mattermost.js
@@ -17,15 +17,15 @@
 var env = process.env;
 var util = require('util');
 var utils = require('./../utils');
-var DefaultAdapter = require('./default');
+var SlackLikeAdapter = require('./slack-like');
 
 
 function MattermostAdapter(robot) {
   var self = this;
-  DefaultAdapter.call(self, robot);
+  SlackLikeAdapter.call(self, robot);
 }
 
-util.inherits(MattermostAdapter, DefaultAdapter);
+util.inherits(MattermostAdapter, SlackLikeAdapter);
 
 MattermostAdapter.prototype.postData = function(data) {
   var self = this;

--- a/src/lib/adapters/mattermost.js
+++ b/src/lib/adapters/mattermost.js
@@ -17,15 +17,15 @@
 var env = process.env;
 var util = require('util');
 var utils = require('./../utils');
-var SlackAdapter = require('./slack');
+var DefaultAdapter = require('./default');
 
 
 function MattermostAdapter(robot) {
   var self = this;
-  SlackAdapter.call(self, robot);
+  DefaultAdapter.call(self, robot);
 }
 
-util.inherits(MattermostAdapter, SlackAdapter);
+util.inherits(MattermostAdapter, DefaultAdapter);
 
 MattermostAdapter.prototype.postData = function(data) {
   var self = this;

--- a/src/lib/adapters/msteams.js
+++ b/src/lib/adapters/msteams.js
@@ -89,11 +89,4 @@ MSTeamsAdapter.prototype.normalizeCommand = function (command) {
   return command;
 }
 
-MSTeamsAdapter.prototype.normalizeAddressee = function(msg) {
-  return {
-    name: msg.message.user.name,
-    room: msg.message.room
-  };
-};
-
 module.exports = MSTeamsAdapter;

--- a/src/lib/adapters/rocketchat.js
+++ b/src/lib/adapters/rocketchat.js
@@ -17,15 +17,15 @@
 var env = process.env;
 var util = require('util');
 var utils = require('./../utils');
-var SlackAdapter = require('./slack');
+var SlackLikeAdapter = require('./slack-like');
 
 
 function RocketChatAdapter(robot) {
   var self = this;
-  SlackAdapter.call(self, robot);
+  SlackLikeAdapter.call(self, robot);
 }
 
-util.inherits(RocketChatAdapter, SlackAdapter);
+util.inherits(RocketChatAdapter, SlackLikeAdapter);
 
 RocketChatAdapter.prototype.postData = function(data) {
   var self = this;

--- a/src/lib/adapters/slack-like.js
+++ b/src/lib/adapters/slack-like.js
@@ -1,0 +1,62 @@
+// Copyright 2019 Extreme Networks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+"use strict";
+
+var util = require('util');
+var utils = require('./../utils');
+var DefaultAdapter = require('./default');
+
+
+// NOTE: Be careful about making changes to this adapter, because the adapters
+//       for Mattermost, Cisco Spark, and Rocketchat all inherit from this one
+function SlackLikeAdapter(robot) {
+  var self = this;
+  DefaultAdapter.call(self, robot);
+}
+
+util.inherits(SlackLikeAdapter, DefaultAdapter);
+
+SlackLikeAdapter.prototype.postData = function(data) {
+  throw Error("Children of SlackLikeAdapter must override postData");
+};
+
+SlackLikeAdapter.prototype.formatData = function(data) {
+  if (utils.isNull(data)) {
+    return "";
+  }
+  // For slack we do not truncate or format the result. This is because
+  // data is posted to slack as a message attachment.
+  return data;
+};
+
+SlackLikeAdapter.prototype.formatRecipient = function(recipient) {
+  return recipient;
+};
+
+SlackLikeAdapter.prototype.normalizeCommand = function(command) {
+  var self = this;
+  command = DefaultAdapter.prototype.normalizeCommand.call(self, command);
+  // replace left double quote with regular quote
+  command = command.replace(/\u201c/g, '\u0022');
+  // replace right double quote with regular quote
+  command = command.replace(/\u201d/g, '\u0022');
+  // replace left single quote with regular apostrophe
+  command = command.replace(/\u2018/g, '\u0027');
+  // replace right single quote with regular apostrophe
+  command = command.replace(/\u2019/g, '\u0027');
+  return command;
+};
+
+module.exports = SlackLikeAdapter;

--- a/src/lib/adapters/slack.js
+++ b/src/lib/adapters/slack.js
@@ -18,14 +18,14 @@ var env = process.env;
 var util = require('util');
 var utils = require('./../utils');
 var messages = require('./../slack-messages');
-var DefaultAdapter = require('./default');
+var SlackLikeAdapter = require('./slack-like');
 
 
 // NOTE: Be careful about making changes to this adapter, because the adapters
 //       for Mattermost, Cisco Spark, and Rocketchat all inherit from this one
 function SlackAdapter(robot) {
   var self = this;
-  DefaultAdapter.call(self, robot);
+  SlackLikeAdapter.call(self, robot);
 
   // We monkey patch sendMessage function to send "parse" argument with the message so the text is not
   // formatted and parsed on the server side.
@@ -57,7 +57,7 @@ function SlackAdapter(robot) {
   }
 };
 
-util.inherits(SlackAdapter, DefaultAdapter);
+util.inherits(SlackAdapter, SlackLikeAdapter);
 
 SlackAdapter.prototype.postData = function(data) {
   var self = this;
@@ -222,33 +222,6 @@ SlackAdapter.prototype.postData = function(data) {
   } else {
     self.robot.adapter.client.send(envelope, pretext + split_message.pretext);
   }
-};
-
-SlackAdapter.prototype.formatData = function(data) {
-  if (utils.isNull(data)) {
-    return "";
-  }
-  // For slack we do not truncate or format the result. This is because
-  // data is posted to slack as a message attachment.
-  return data;
-};
-
-SlackAdapter.prototype.formatRecipient = function(recipient) {
-  return recipient;
-};
-
-SlackAdapter.prototype.normalizeCommand = function(command) {
-  var self = this;
-  command = SlackAdapter.super_.prototype.normalizeCommand.call(self, command);
-  // replace left double quote with regular quote
-  command = command.replace(/\u201c/g, '\u0022');
-  // replace right double quote with regular quote
-  command = command.replace(/\u201d/g, '\u0022');
-  // replace left single quote with regular apostrophe
-  command = command.replace(/\u2018/g, '\u0027');
-  // replace right single quote with regular apostrophe
-  command = command.replace(/\u2019/g, '\u0027');
-  return command;
 };
 
 module.exports = SlackAdapter;

--- a/src/lib/adapters/spark.js
+++ b/src/lib/adapters/spark.js
@@ -18,15 +18,15 @@ var env = process.env;
 var util = require('util');
 var utils = require('./../utils');
 var DefaultAdapter = require('./default');
-var SlackAdapter = require('./slack');
+var SlackLikeAdapter = require('./slack-like');
 
 
 function SparkAdapter(robot) {
   var self = this;
-  SlackAdapter.call(self, robot);
+  SlackLikeAdapter.call(self, robot);
 }
 
-util.inherits(SparkAdapter, SlackAdapter);
+util.inherits(SparkAdapter, SlackLikeAdapter);
 
 SparkAdapter.prototype.postData = function(data) {
   var self = this;


### PR DESCRIPTION
This PR is on top of #190.

This PR slightly refactors the adapter inheritance for Slack-like adapters.

It adds in an intermediary `SlackLikeAdapter` for the Slack-like providers. This should make it easier to use `DefaultAdapter` methods in subclasses, like with what is done in `SparkAdapter.formatData` and `SlackLikeAdapter.normalizeCommand`.

This makes things a bit easier:

```diff
-ThisAdapter.super_.prototype.customMethod.call(...)
+DefaultAdapter.customMethod(...)
```

I also removed the `normalizeAddressee` from the MS Teams adapter, since it was an override of [the same function from `DefaultAdapter`](https://github.com/StackStorm/hubot-stackstorm/blob/3a14cdd8ed73fb7f2c3647df215e02035065eebd/src/lib/adapters/default.js#L82) (and the MS Teams adapter inherits from `DefaultAdapter`). The two functions were identical, however, so it makes no sense to override that function. And since the two functions were identical, I didn't need to change the tests at all for this fix.

~Once #190 is merged, I will either rebase and merge this with GitHub, or I will manually rebase this branch on that one, force push, and merge it.~ Done.