### PR TITLE
Fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "main": "index.js",
   "scripts": {
     "eslint": "eslint .",
-    "test": "nyc mocha"
+    "test": "nyc mocha --exit"
   },
   "nyc": {
     "temp-directory": "./coverage/.nyc_output",

--- a/test/test-formatdata.js
+++ b/test/test-formatdata.js
@@ -395,7 +395,7 @@ describe('SparkFormatter', function() {
     var msg = {
       message: {
         user: {
-          room: "SparkRoomName",
+          roomId: "SparkRoomId",
           name: "SparkUserName"
         }
       }
@@ -404,7 +404,7 @@ describe('SparkFormatter', function() {
     expect(o.name).to.be.an('string');
     expect(o.name).to.equal('SparkUserName');
     expect(o.room).to.be.an('string');
-    expect(o.room).to.equal('SparkRoomName');
+    expect(o.room).to.equal('SparkRoomId');
   });
 });
 

--- a/test/test-postdata.js
+++ b/test/test-postdata.js
@@ -902,7 +902,9 @@ describe("spark post data", function() {
     expect(robot.messageRoom).to.have.been.calledOnce;
     expect(robot.messageRoom).to.have.been.calledWith(
       {
-        channel: input.channel,
+        id: input.channel,
+        roomId: input.channel,
+        name: input.user,
         extra: undefined
       },
       user + "normal boring text"
@@ -912,6 +914,7 @@ describe("spark post data", function() {
   it('should post to room and not mention a user', function() {
     robot.messageRoom = sinon.spy();
     var input = {
+      user: 'stanley',
       channel: '#stackstorm',
       message: "normal boring text",
       whisper: false
@@ -922,10 +925,12 @@ describe("spark post data", function() {
     expect(robot.messageRoom).to.have.been.calledOnce;
     expect(robot.messageRoom).to.have.been.calledWith(
       {
-        channel: input.channel,
+        id: input.channel,
+        roomId: input.channel,
+        name: input.user,
         extra: undefined
       },
-      "normal boring text"
+      "stanley: normal boring text"
     );
   });
 
@@ -947,7 +952,9 @@ describe("spark post data", function() {
     expect(robot.messageRoom).to.have.been.calledOnce;
     expect(robot.messageRoom).to.have.been.calledWith(
       {
-        channel: input.channel,
+        id: input.channel,
+        roomId: input.channel,
+        name: input.user,
         extra: {
           custom1: "attribute1",
           custom2: "attribute2"
@@ -992,7 +999,9 @@ describe("spark post data", function() {
     expect(robot.messageRoom).to.have.been.calledOnce;
     expect(robot.messageRoom).to.have.been.calledWith(
       {
-        channel: input.channel,
+        id: input.channel,
+        roomId: input.channel,
+        name: input.user,
         extra: undefined
       },
       user + "NORMAL PRETEXT\nnormal boring text"


### PR DESCRIPTION
For PR #200 it looked like the [build passed](https://travis-ci.org/github/StackStorm/hubot-stackstorm/builds/671976636). But looking at the individual jobs:

```
...
  141 passing (482ms)
  5 failing
  1) SparkFormatter
       should normalize the addressee:
     AssertionError: expected undefined to be a string
      at Context.<anonymous> (test/test-formatdata.js:406:26)
  
  2) spark post data
       should post to room and mention a user:
     AssertionError: expected messageRoom to have been called with arguments { channel: "#stackstorm", extra: undefined }, stanley: normal boring text
{ extra: undefined, id: "#stackstorm", name: "stanley", roomId: "#stackstorm" } { channel: "#stackstorm", extra: undefined } 
stanley: normal boring text
      at Context.<anonymous> (test/test-postdata.js:903:44)
  
  3) spark post data
       should post to room and not mention a user:
     AssertionError: expected messageRoom to have been called with arguments { channel: "#stackstorm", extra: undefined }, normal boring text
{ extra: undefined, id: "#stackstorm", name: undefined, roomId: "#stackstorm" } { channel: "#stackstorm", extra: undefined } 
normal boring text
      at Context.<anonymous> (test/test-postdata.js:923:44)
  
  4) spark post data
       should post to room with extra:
     AssertionError: expected messageRoom to have been called with arguments { channel: "#stackstorm", extra: { custom1: "attribute1", custom2: "attribute2" } }, stanley: normal boring text
{
  extra: { custom1: "attribute1", custom2: "attribute2" },
  id: "#stackstorm",
  name: "stanley",
  roomId: "#stackstorm"
} { channel: "#stackstorm", extra: { custom1: "attribute1", custom2: "attribute2" } } 
stanley: normal boring text
      at Context.<anonymous> (test/test-postdata.js:948:44)
  
  5) spark post data
       should post message with pretext to room:
     AssertionError: expected messageRoom to have been called with arguments { channel: "#stackstorm", extra: undefined }, stanley: NORMAL PRETEXT
normal boring text
{ extra: undefined, id: "#stackstorm", name: "stanley", roomId: "#stackstorm" } { channel: "#stackstorm", extra: undefined } 
stanley: NORMAL PRETEXT
normal boring text
      at Context.<anonymous> (test/test-postdata.js:993:44)


---------------------|----------|----------|----------|----------|-------------------|
          .          |     .    |     .    |     .    |     .    |         .         |
          .          |     .    |     .    |     .    |     .    |         .         |
          .          |     .    |     .    |     .    |     .    |         .         |
---------------------|----------|----------|----------|----------|-------------------|

The command "npm test" exited with 0.
store build cache

Done. Your build exited with 0.
```

This is due to a bug that has been reported multiple times to mocha:
* https://github.com/mochajs/mocha/issues/3044 - mocha 4 doesn't exit unlike mocha 3
* https://github.com/mochajs/mocha/issues/3559 - Use standard exit codes
* https://github.com/mochajs/mocha/issues/3893 - Mocha exits with 0 exit code with failing tests

This PR fixes this by passing the `--exit` flag to mocha. The first commit properly fails the Travis CI tests, and the second commit fixes the tests to match the changes in PR #200, which were tested against a real instance of Cisco Spark/Webex.

Using the [`--exit` flag](https://mochajs.org/#-exit) isn't exactly meant to solve this problem, but it does.