### PR TITLE
Update st2client.js to 1.2.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 in development
 --------------
 
+0.10.3
+------
+
+* Update st2client.js to 1.2.2 [PR #203] (change)
+
 0.10.2
 ------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -371,9 +371,12 @@
       "dev": true
     },
     "axios": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.7.0.tgz",
-      "integrity": "sha1-SJwmkETVBm36LGTHScsTGxdvSno="
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -1752,6 +1755,29 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -5785,11 +5811,11 @@
       "dev": true
     },
     "st2client": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/st2client/-/st2client-1.2.1.tgz",
-      "integrity": "sha512-7xZNyGNaL2ekoNJcSbishtpfOJ5p53oBcoZPfZTxywJC17iGbqrP09wRCPuFUtrkUReH+4dLC4GxgxCx/LLGWg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/st2client/-/st2client-1.2.2.tgz",
+      "integrity": "sha512-mutxKjPoDAfqwWXFOK8QtFts+WazjVWDgMaZ6eeSCDRP5jXVxvnNvRg4dBGMF0JRoP6RIryuCCLvVd3r5lDyTA==",
       "requires": {
-        "axios": "^0.7.0",
+        "axios": "^0.19.0",
         "eventsource": "^0.1.4",
         "lodash": "^4.17.15",
         "object.assign": "^1.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-stackstorm",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-stackstorm",
   "description": "A hubot plugin for integrating with StackStorm event-driven infrastructure automation platform.",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "author": "StackStorm, Inc. <info@stackstorm.com>",
   "license": "Apache-2.0",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "coffee-script": "1.12.7",
     "lodash": "^4.17.11",
     "rsvp": "^4.8.4",
-    "st2client": "^1.1.3",
+    "st2client": "^1.2.2",
     "truncate": "^2.0.1",
     "uuid": "^3.0.0"
   },


### PR DESCRIPTION
This PR updates st2client.js from `1.1.3` to version `1.2.2`, so it pulls in the changes from PR StackStorm/st2client.js#76.