### PR TITLE
Update version to 0.11.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 in development
 --------------
 
+0.11.1
+------
+
+* Update ``ini`` dependency to 1.3.8 (improvement) #212
+
 0.11.0
 ------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-stackstorm",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-stackstorm",
   "description": "A hubot plugin for integrating with StackStorm event-driven infrastructure automation platform.",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "author": "StackStorm, Inc. <info@stackstorm.com>",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
PR #211 bumped the package version to 0.11.0 in `package-lock.json`, but PR #207 bumped the version to 0.11.0 in `package.json`. NPM already has version 0.11.0, so we need to bump to version 0.11.1 in both `package.json` and `package-lock.json` to push the new version to NPM.