### PR TITLE
Handle slack injected nbsp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ in development
 ------
 
 * Clean slack-injected latin1 nbsp character (/xA0) from command to improve command recognition.
-  Slack will sometimes replace a space with /xA0, ofen near something that renders as a link.
+  Slack will sometimes replace a space with /xA0, often near something that renders as a link.
   Now, when someone copies that command, they can paste it and still have hubot recognize it.
   (improvement) #214
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ in development
 --------------
 * Update ``lodash`` and ``st2client`` dependencies (improvement)
 
+0.12.0
+------
+
+* Clean slack-injected latin1 nbsp character (/xA0) from command to improve command recognition.
+  Slack will sometimes replace a space with /xA0, ofen near something that renders as a link.
+  Now, when someone copies that command, they can paste it and still have hubot recognize it.
+  (improvement) #214
+
 0.11.2
 ------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-stackstorm",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-stackstorm",
   "description": "A hubot plugin for integrating with StackStorm event-driven infrastructure automation platform.",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "author": "StackStorm, Inc. <info@stackstorm.com>",
   "license": "Apache-2.0",
   "keywords": [

--- a/src/lib/adapters/slack-like.js
+++ b/src/lib/adapters/slack-like.js
@@ -56,11 +56,6 @@ SlackLikeAdapter.prototype.normalizeCommand = function(command) {
   command = command.replace(/\u2018/g, '\u0027');
   // replace right single quote with regular apostrophe
   command = command.replace(/\u2019/g, '\u0027');
-  // replace non-breaking space with regular space
-  // first the unicode variant, so we don't cut it in half,
-  // then the latin1 variant (thanks to slack)
-  command = command.replace(/\u00A0/g, ' ');
-  command = command.replace(/\xA0/g, ' ');
   return command;
 };
 

--- a/src/lib/adapters/slack-like.js
+++ b/src/lib/adapters/slack-like.js
@@ -56,6 +56,11 @@ SlackLikeAdapter.prototype.normalizeCommand = function(command) {
   command = command.replace(/\u2018/g, '\u0027');
   // replace right single quote with regular apostrophe
   command = command.replace(/\u2019/g, '\u0027');
+  // replace non-breaking space with regular space
+  // first the unicode variant, so we don't cut it in half,
+  // then the latin1 variant (thanks to slack)
+  command = command.replace(/\u00A0/g, ' ');
+  command = command.replace(/\xA0/g, ' ');
   return command;
 };
 

--- a/src/lib/adapters/slack.js
+++ b/src/lib/adapters/slack.js
@@ -224,4 +224,15 @@ SlackAdapter.prototype.postData = function(data) {
   }
 };
 
+SlackAdapter.prototype.normalizeCommand = function(command) {
+  var self = this;
+  command = SlackLikeAdapter.prototype.normalizeCommand.call(self, command);
+  // replace non-breaking space with regular space
+  // first the unicode variant, so we don't cut it in half,
+  // then the latin1 variant (thanks to slack)
+  command = command.replace(/\u00A0/g, ' ');
+  command = command.replace(/\xA0/g, ' ');
+  return command;
+}
+
 module.exports = SlackAdapter;

--- a/test/test-formatdata.js
+++ b/test/test-formatdata.js
@@ -88,6 +88,30 @@ describe('SlackFormatter', function() {
     expect(o).to.equal('run remote \'uname -a\' \'localhost, 127.0.0.1\'');
   });
 
+  // copy/paste a command in slack. Sometimes (esp w/ URLs) it replaces a space with this char.
+  it('should normalize command with slack-injected latin1 non-breaking space', function() {
+    var adapter = adapters.getAdapter(adapterName, robot);
+    var o = adapter.normalizeCommand('run local\xA0"uname -a"');
+    expect(o).to.be.an('string');
+    expect(o).to.equal('run local "uname -a"');
+  });
+
+  // slack injects the latin1 variant (above) but we can't break the unicode variant.
+  it('should normalize command with unicode non-breaking space', function() {
+    var adapter = adapters.getAdapter(adapterName, robot);
+    var o = adapter.normalizeCommand('run local\u00A0"uname -a"');
+    expect(o).to.be.an('string');
+    expect(o).to.equal('run local "uname -a"');
+  });
+
+  // not likely. Just making sure this doesn't mangle the unicode chars.
+  it('should normalize command with mixed latin1/unicode non-breaking space', function() {
+    var adapter = adapters.getAdapter(adapterName, robot);
+    var o = adapter.normalizeCommand('run\xA0\u00A0\xA0local\u00A0\xA0\u00A0"uname -a"');
+    expect(o).to.be.an('string');
+    expect(o).to.equal('run   local   "uname -a"');
+  });
+
   it('should normalize the addressee', function() {
     var adapter = adapters.getAdapter(adapterName, robot);
     var msg = {


### PR DESCRIPTION
copy/paste in slack proves problematic
because sometimes slack replaces a space
with the Latin1 non breaking space char /xA0

this cleans that up so that alias commands
and extra args can be appropriately recognized