### PR TITLE
Allow threading for the ack and result messages for the slack backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ in development
 * Use Github Actions for tests.
 * Remove TravisCI.
 
+0.12.1
+------
+
+* Allow responding in a thread for the ack/result in slack (improvement) #237
+
 0.12.0
 ------
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-stackstorm",
   "description": "A hubot plugin for integrating with StackStorm event-driven infrastructure automation platform.",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "author": "StackStorm, Inc. <info@stackstorm.com>",
   "license": "Apache-2.0",
   "keywords": [

--- a/src/lib/adapters/slack.js
+++ b/src/lib/adapters/slack.js
@@ -84,6 +84,11 @@ SlackAdapter.prototype.postData = function(data) {
     };
   }
 
+  //If extra.slack.thread_response is set, we will send the response in a thread (SLACK ONLY)
+  if (data.extra && data.extra.slack && data.extra.slack.thread_response) {
+    envelope.message = {"thread_ts": data.context.message.id};
+  }
+
   // Allow packs to specify arbitrary keys
   if (data.extra && data.extra.slack && data.extra.slack.attachments) {
     // Action:

--- a/src/lib/stackstorm_api.js
+++ b/src/lib/stackstorm_api.js
@@ -331,6 +331,12 @@ StackStorm.prototype.sendAck = function (msg, res) {
     }
   }
 
+  // If ack.extra.slack.thread_response is set in the action-alias definition,
+  // then we will thread the ACK response message (SLACK ONLY)
+  if (res.extra && res.extra.slack && res.extra.slack.thread_response) {
+    msg.message.thread_ts = msg.message.id;
+  }
+
   if (res.message) {
     return msg.send(res.message + history);
   }


### PR DESCRIPTION
Fixes: https://github.com/StackStorm/hubot-stackstorm/issues/161

Example action alias definition

```
ack:
  extra:
    slack:
      thread_response: true
  format: ":speech_balloon: ACK, Looking that up for you..."
  append_url: false
result:
  extra:
    slack:
      thread_response: true
  format: |
    On-Call:
    Name: {{execution.result.output.result.name}}
    Username: `@{{execution.result.output.result.user_name}}`
    Phone: {{execution.result.output.result.mobile_phone}}
```
<img width="677" alt="Screenshot 2024-09-30 at 1 17 33 PM" src="https://github.com/user-attachments/assets/5beff5fb-a026-4eaf-89ae-3522ae0f3f44">


Hubot-slack checks for the existence of `envelope.message.thread_ts` in order to thread the response instead of sending to the open channel https://github.com/slackapi/hubot-slack/blob/main/src/client.coffee#L191

